### PR TITLE
feature centerInfoUpdate

### DIFF
--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/authentication/UserDetailsServiceImpl.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/authentication/UserDetailsServiceImpl.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 /**
  * ユーザー情報生成
  *
- * @author your name
+ * @author Okuma
  * 
  */
 @Component

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/config/BeanDefine.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/config/BeanDefine.java
@@ -8,7 +8,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 /**
  * Bean定義クラス
  *
- * @author your name
+ * @author Okuma
  * 
  */
 @Configuration

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/config/WebSecurityConfig.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/config/WebSecurityConfig.java
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 /**
  * WebSecurityConfig
  *
- * @author your name
+ * @author Okuma
  * 
  */
 @Configuration

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/CategoryConsts.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/CategoryConsts.java
@@ -1,0 +1,29 @@
+package com.digitalojt.web.consts;
+/**
+ * 分類 Enumクラス
+ * 
+ * @author Okuma
+ */
+public enum CategoryConsts {
+
+	FRAME("フレーム"),
+	PROPELLER("プロペラ"),
+	ELECTRICMOTOR("電動モーター"),
+	ELECTRICSPEEDREGULATOR("電子速度調整器"),
+	BATTERY("バッテリー"),
+	FLIGHTCONTROLLER("フライトコントローラー"),
+	REMOTECONTROLLER("リモートコントローラー"),	
+	RECEIVER("受信機"),
+	GPSMODULE("GPSモジュール"),
+	CAMERASENSOR("カメラ／センサー");
+	
+	private final String category;
+
+	CategoryConsts(String category) {
+        this.category = category;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ErrorMessage.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ErrorMessage.java
@@ -3,18 +3,18 @@ package com.digitalojt.web.consts;
 /**
  * エラーメッセージ定数クラス
  * 
- * @author your name
+ * @author Okuma
  *
  */
 public class ErrorMessage {
-	
+
 	// ログイン情報の入力に誤りがあった場合に、出力するエラーメッセージのID
-	public static final String  LOGIN_WRONG_INPUT = "login.wrongInput";
+	public static final String LOGIN_WRONG_INPUT = "login.wrongInput";
 
 	// すべての項目が空の場合のエラーメッセージ
 	public static final String ALL_FIELDS_EMPTY_ERROR_MESSAGE = "allField.empty";
 
-	// 空文字検索に関するエラーメッセージ
+	// 空文字検索や予期しない入力に関するエラーメッセージ
 	public static final String UNEXPECTED_INPUT_ERROR_MESSAGE = "unexpected.input";
 
 	// 不正な文字列を使用した検索に関するエラーメッセージ
@@ -22,4 +22,58 @@ public class ErrorMessage {
 
 	// 文字超過に関するエラーメッセージ
 	public static final String CENTER_NAME_LENGTH_ERROR_MESSAGE = "centerName.length.wrongInput";
+
+	// 文字超過に関するエラーメッセージ
+	public static final String STOCK_NAME_LENGTH_ERROR_MESSAGE = "stockName.length.wrongInput";
+
+	// 文字超過に関するエラーメッセージ
+	public static final String CATEGORY_LENGTH_ERROR_MESSAGE = "category.length.wrongInput";
+
+	// 分類名が空の場合のエラーメッセージ
+	public static final String CATEGORY_FIELDS_EMPTY_ERROR_MESSAGE = "category.empty";
+
+	// 分類IDが最大数以上の場合のエラーメッセージ
+	public static final String CATEGORY_ID_MAXIMUM_LIMIT_ERROR_MESSAGE = "categoryId.maximum.limit";
+
+	// 在庫数項目で不正な値を使用した検索に関するエラーメッセージ
+	public static final String STOCK_NUM_INPUT_ERROR_MESSAGE = "stockNum.input";
+
+	// 郵便番号に関するエラーメッセージ
+	public static final String INVALID_POST_CODE_ERROR_MESSAGE = "invalid.postCode.Input";
+
+	// 文字超過に関するエラーメッセージ（住所）
+	public static final String ADDRESS_LENGTH_ERROR_MESSAGE = "address.length.wrongInput";
+
+	// 電話番号に関するエラーメッセージ
+	public static final String INVALID_PHONE_NUMBER_ERROR_MESSAGE = "invalid.phoneNumber.Input";
+
+	// 文字超過に関するエラーメッセージ（管理者名）
+	public static final String MANAGER_NAME_LENGTH_ERROR_MESSAGE = "managerName.length.wrongInput";
+
+	// 最大保管容量（m³）に関するエラーメッセージ
+	public static final String INVALID_MAX_STORAGE_CAPACITY_ERROR_MESSAGE = "invalid.maxStorageCapacity.Input";
+
+	// 現在保管容量（m³）に関するエラーメッセージ
+	public static final String INVALID_CURRENT_STORAGE_CAPACITY_ERROR_MESSAGE = "invalid.currentStorageCapacity.Input";
+
+	// 現在保管容量（m³）に関するエラーメッセージ
+	public static final String INVALID_CURRENT_STORAGE_CAPACITY_OVER_ERROR_MESSAGE = "invalid.currentStorageCapacity.over.Input";
+
+	// 文字超過に関するエラーメッセージ（備考）
+	public static final String NOTES_LENGTH_ERROR_MESSAGE = "notes.length.wrongInput";
+
+	// 在庫情報に紐づくセンター情報を削除使用とした場合のエラーメッセージ
+	public static final String LINKED_CENTER_ID = "linked.centerId";
+
+	// センターIDに紐づくデータが空の場合のエラーメッセージ
+	public static final String NULL_CENTER_ID_MESSAGE = "null.centerId";
+
+	// DataAccessExceptionの場合のエラーメッセージ
+	public static final String DATA_ACCESS_ERROR_MESSAGE = "dataAccess.exception";
+
+	// NullPointerExceptionの場合のエラーメッセージ
+	public static final String NULL_POINTER_ERROR_MESSAGE = "nullPointer.exception";
+
+	// Exceptionの場合のエラーメッセージ
+	public static final String ALL_ERROR_MESSAGE = "all.exception";
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/InvalidCharacter.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/InvalidCharacter.java
@@ -3,28 +3,40 @@ package com.digitalojt.web.consts;
 /**
  * 不正文字を管理するEnumクラス
  * 
- * @author your name
+ * @author Okuma
  */
 public enum InvalidCharacter {
 
-    CURLY_BRACE_OPEN('{'),
-    CURLY_BRACE_CLOSE('}'),
-    PARENTHESIS_OPEN('('),
-    PARENTHESIS_CLOSE(')'),
-    EQUAL_SIGN('='),
-    AMPERSAND('&'),
-    SEMICOLON(';'),
-    DOLLAR_SIGN('$'),
-    QUESTION_MARK('?'),
-    ASTERISK('*');
+	CURLY_BRACE_OPEN('{'),
+	CURLY_BRACE_CLOSE('}'),
+	PARENTHESIS_OPEN('('),
+	PARENTHESIS_CLOSE(')'),
+	EQUAL_SIGN('='),
+	AMPERSAND('&'),
+	SEMICOLON(';'),
+	DOLLAR_SIGN('$'),
+	QUESTION_MARK('?'),
+	ASTERISK('*'),
+	HALF_SPACE(' '),
+	SINGLE_QUOTATION('\'');
 
-    private final char character;
+	private final char character;
 
-    InvalidCharacter(char character) {
-        this.character = character;
-    }
+	/** 
+	 * InvalidCharacter列挙型のコンストラクタ
+	 *  
+	 * @param character 列挙定数が表す文字
+	 */
+	InvalidCharacter(char character) {
+		this.character = character;
+	}
 
-    public char getCharacter() {
-        return character;
-    }
+	/**
+	 * 列挙定数が表す文字を取得
+	 *
+	 * @return 列挙定数が表す文字 
+	 */
+	public char getCharacter() {
+		return character;
+	}
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/OperationalStatus.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/OperationalStatus.java
@@ -1,0 +1,21 @@
+package com.digitalojt.web.consts;
+/**
+ * 検索範囲の条件(以上・以下） Enumクラス
+ * 
+ * @author Okuma
+ */
+public enum OperationalStatus {
+
+	ACTIVE(0),
+	INACTIVE(1);
+
+    private final int type;
+
+    OperationalStatus(int type) {
+        this.type = type;
+    }
+
+    public int getType() {
+        return type;
+    }
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ParamsLimits.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ParamsLimits.java
@@ -1,0 +1,60 @@
+package com.digitalojt.web.consts;
+
+/**
+ * 制限の定数クラス
+ *
+ * @author Okuma
+ * 
+ * 
+ */
+public class ParamsLimits {
+
+	// 分類名の最大文字数
+	public static final int CATEGORY_MAX_LENGTH = 15;
+
+	// 在庫センター名の最大文字数
+	public static final int CENTER_INFO_MAX_LENGTH = 20;
+
+	// 在庫名の最大文字数
+	public static final int STOCK_NAME_MAX_LENGTH = 20;
+
+	// 在庫数の最大数
+	public static final int STOCK_MAX_NUM = 9999;
+
+	// 在庫数の最小数
+	public static final int STOCK_MIN_NUM = 1;
+
+	// 分類IDの最大数
+	public static final int CATEGORYID_MAX_NUM = 10;
+
+	// 分類IDの最小数
+	public static final int CATEGORYID_MIN_NUM = 1;
+
+	// 住所の最大文字数
+	public static final int ADDRESS_MAX_LENGTH = 15;
+
+	//管理者名の最大文字数
+	public static final int MANAGER_NAME_MAX_LENGTH = 20;
+
+	//最大保管容量（m³）の最小数
+	public static final int MIN_STORAGE_CAPACITY = 1;
+
+	//最大保管容量（m³）の最大数
+	public static final int MAX_STORAGE_CAPACITY = 9999;
+
+	//現在保管容量（m³）の最小数
+	public static final int MIN__CURRENT_STORAGE_CAPACITY = 0;
+
+	//備考の最大文字数
+	public static final int NOTES_MAX_LENGTH = 100;
+
+	//センターIDの数値
+	public static final String CENTER_ID_NUMERIC = "/^[0-9]+$/";
+
+	// 郵便番号のフォーマット
+	public static final String POST_CODE_FORMAT = "^[0-9]{3}-[0-9]{4}$";
+
+	// 電話番号のフォーマット
+	public static final String PHONE_NUMBER_FORMAT = "^[0-9]{2,4}-[0-9]{2,4}-[0-9]{4}$";
+
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/RangeType.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/RangeType.java
@@ -1,0 +1,21 @@
+package com.digitalojt.web.consts;
+/**
+ * 検索範囲の条件(以上・以下） Enumクラス
+ * 
+ * @author Okuma
+ */
+public enum RangeType {
+
+	OVER("以上"),
+	UNDER("以下");
+
+    private final String type;
+
+    RangeType(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/Region.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/Region.java
@@ -3,7 +3,7 @@ package com.digitalojt.web.consts;
 /**
  * 都道府県 Enumクラス
  * 
- * @author your name
+ * @author Okuma
  */
 public enum Region {
 

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ResultMessage.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ResultMessage.java
@@ -1,0 +1,23 @@
+package com.digitalojt.web.consts;
+
+/**
+ * 結果メッセージ定数クラス
+ * 
+ * @author Okuma
+ *
+ */
+public class ResultMessage {
+
+	// 新規登録完了のメッセージ
+	public static final String REGISTRATION_COMPLETED = "registration.completed";
+
+	// 新規登録エラーのメッセージ
+	public static final String REGISTRATION_ERROR = "registration.error";
+
+	// 更新完了のメッセージ
+	public static final String UPDATE_COMPLETED = "update.completed";
+
+	// 更新エラーのメッセージ
+	public static final String UPDATE_ERROR = "update.error";
+
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
@@ -3,29 +3,61 @@ package com.digitalojt.web.consts;
 /**
  * URL定数クラス
  *
- * @author your name
+ * @author Okuma
+ * 
  * 
  */
 public class UrlConsts {
 
 	// ログイン
 	public static final String LOGIN = "/login";
-	
+
 	// 認証
 	public static final String AUTHENTICATE = "/authenticate";
-	
+
 	// 在庫一覧画面
 	public static final String STOCK_LIST = "/admin/stockList";
-	
+
+	// 在庫一覧画面　表示
+	public static final String STOCK_LIST_INDEX = "/admin/stockList/index";
+
 	// 在庫一覧画面 検索
 	public static final String STOCK_LIST_SEARCH = "/admin/stockList/search";
-	
+
+	// 分類情報管理画面
+	public static final String CATEGORY_INFO_CONTROL = "/admin/categoryInfoControl";
+
+	// 分類情報管理画面 検索
+	public static final String CATEGORY_INFO_CONTROL_SEARCH = "/admin/categoryInfoControl/search";
+
 	// 在庫センター情報画面
-	public static final String  CENTER_INFO = "/admin/centerInfo";
-	
+	public static final String CENTER_INFO = "/admin/centerInfo";
+
+	// 在庫センター情報画面　表示
+	public static final String CENTER_INFO_INDEX = "/admin/centerInfo/index";
+
 	// 在庫センター情報画面 検索
 	public static final String CENTER_INFO_SEARCH = "/admin/centerInfo/search";
-	
+
+	// 在庫センター情報画面 登録
+	public static final String CENTER_INFO_REGISTER = "/admin/centerInfo/register";
+
+	// 在庫センター情報画面 登録完了
+	public static final String CENTER_INFO_REGISTRATION_COMPLETED = "/admin/centerInfo/registrationCompleted";
+
+	// 在庫センター情報画面 更新/削除画面　表示
+	public static final String CENTER_INFO_DETAILS = "/admin/centerInfo/details/{centerId}";
+
+	// 在庫センター情報画面 更新/削除画面
+	public static final String CENTER_INFO_UPDATE = "/admin/centerInfo/update";
+
+	// 在庫センター情報画面 削除確認画面　表示
+	public static final String CENTER_INFO_DELETE_CONFIRM = "/admin/centerInfo/delete/{centerId}";
+
+	// 在庫センター情報画面 削除確認画面
+	public static final String CENTER_INFO_DELETE = "/admin/centerInfo/delete";
+
 	// 認証不要画面
-	public static final String[] NO_AUTHENTICATION = {LOGIN, AUTHENTICATE};
+	public static final String[] NO_AUTHENTICATION = { LOGIN, AUTHENTICATE };
+
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/AbstractController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/AbstractController.java
@@ -3,9 +3,9 @@ package com.digitalojt.web.controller;
 /**
  * 抽象コントローラー
  *
- * @author your name
+ * @author Okuma
  *
  */
-public class AbstractController {
+public abstract class AbstractController {
 
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
@@ -1,0 +1,192 @@
+package com.digitalojt.web.controller;
+
+import java.util.List;
+
+import org.springframework.context.MessageSource;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import com.digitalojt.web.consts.ErrorMessage;
+import com.digitalojt.web.consts.UrlConsts;
+import com.digitalojt.web.entity.CategoryInfo;
+import com.digitalojt.web.form.CategoryInfoControlForm;
+import com.digitalojt.web.service.CategoryInfoService;
+import com.digitalojt.web.util.MessageManager;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 分類情報管理画面のコントローラークラス
+ * 
+ * @author Okuma
+ * 
+ */
+@Controller
+@RequiredArgsConstructor
+public class CategoryInfoControlController {
+
+	/** 分類情報 サービス */
+	private final CategoryInfoService categoryInfoService;
+
+	/** メッセージソース */
+	private final MessageSource messageSource;
+
+	/**
+	 * 初期表示
+	 * 
+	 * @param model
+	 * @return
+	 */
+	@GetMapping(UrlConsts.CATEGORY_INFO_CONTROL)
+	public String index(Model model) {
+
+		/*		// 分類名取得を定数クラス→DB取得に変更のためコメント化
+				// 分類 Enumをリストに変換
+				List<CategoryConsts> categoryConsts = Arrays.asList(CategoryConsts.values());
+				// 分類一覧情報をセット
+				model.addAttribute("categoryConsts", categoryConsts);
+		*/
+
+		try {
+			/*			// 全分類情報を取得処理を独立させるためコメント化
+						// 分類情報画面に表示するデータを取得
+						List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData();
+						// 分類一覧情報をセット
+						model.addAttribute("categoryInfoList", categoryInfoList);
+			*/
+			//全分類情報を取得
+			getCategoryInfoList(model);
+
+		} catch (DataAccessException e) {
+			/*			//メッセージ・プロパティにまとめるためコメント化
+						// DB情報取得エラー時のメッセージをセット
+						String dbErrorMsg = "データベース操作中にエラーが発生しました。管理者へ問い合わせください。";
+			*/
+			// エラーメッセージをプロパティファイルから取得
+			String dbErrorMsg = MessageManager.getMessage(messageSource, ErrorMessage.DATA_ACCESS_ERROR_MESSAGE);
+			// DB情報取得エラー時のメッセージをセット
+			model.addAttribute("dbErrorMsg", dbErrorMsg);
+		}
+
+		return "admin/categoryInfoControl/index";
+	}
+
+	/**
+	 * 検索結果表示
+	 * 
+	 * @param model
+	 * @param form
+	 * @return
+	 */
+	@PostMapping(UrlConsts.CATEGORY_INFO_CONTROL_SEARCH)
+	public String search(Model model, @Valid CategoryInfoControlForm form, BindingResult bindingResult) {
+
+		// Valid項目チェック
+		if (bindingResult.hasErrors()) {
+
+			// エラーメッセージをプロパティファイルから取得
+			String errorMsg = MessageManager.getMessage(messageSource,
+					bindingResult.getGlobalError().getDefaultMessage());
+			model.addAttribute("errorMsg", errorMsg);
+
+			/*			// 分類名取得を定数クラス→DB取得に変更のためコメント化
+						// 分類 Enumをリストに変換
+						List<CategoryConsts> categoryConsts = Arrays.asList(CategoryConsts.values());
+			
+						// 分類一覧情報をセット
+						model.addAttribute("categoryConsts", categoryConsts);
+			*/
+
+			try {
+				/*				// 全分類情報を取得処理を独立させるためコメント化
+								// 分類情報画面に表示するデータを取得
+								List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData();
+								// 分類一覧情報をセット
+								model.addAttribute("categoryInfoList", categoryInfoList);
+				*/
+				//全分類情報を取得
+				getCategoryInfoList(model);
+
+			} catch (DataAccessException e) {
+				/*				//メッセージ・プロパティにまとめるためコメント化
+								// DB情報取得エラー時のメッセージをセット
+								String dbErrorMsg = "データベース操作中にエラーが発生しました。管理者へ問い合わせください。";
+				*/
+				// エラーメッセージをプロパティファイルから取得
+				String dbErrorMsg = MessageManager.getMessage(messageSource, ErrorMessage.DATA_ACCESS_ERROR_MESSAGE);
+				// DB情報取得エラー時のメッセージをセット
+				model.addAttribute("dbErrorMsg", dbErrorMsg);
+			}
+
+			return "admin/categoryInfoControl/index";
+		}
+
+		/*		// 分類情報管理画面に表示するデータを取得
+				List<CategoryConsts> categoryConsts = form.getCategoryResearchResult(form.getCategory());
+		
+				// 分類一覧情報をセット
+				model.addAttribute("categoryConsts", categoryConsts);
+		*/
+
+		try {
+			// 分類情報管理画面に表示するデータを取得
+			List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData(form.getCategory());
+			// 分類一覧情報をセット
+			model.addAttribute("categoryInfoList", categoryInfoList);
+		} catch (NullPointerException e) {
+			/*			//メッセージ・プロパティにまとめるためコメント化
+						// DB情報取得エラー時のメッセージをセット
+						String dbErrorMsg = "予期せぬエラーが発生しました。管理者へ問い合わせください。(エラーコード：2)";
+			*/
+			// エラーメッセージをプロパティファイルから取得
+			String dbErrorMsg = MessageManager.getMessage(messageSource, ErrorMessage.NULL_POINTER_ERROR_MESSAGE);
+			// DB情報取得エラー時のメッセージをセット
+			model.addAttribute("dbErrorMsg", dbErrorMsg);
+		} catch (DataAccessException e) {
+			/*			//メッセージ・プロパティにまとめるためコメント化
+						// DB情報取得エラー時のメッセージをセット
+						String dbErrorMsg = "データベース操作中にエラーが発生しました。管理者へ問い合わせください。";
+			*/
+			// エラーメッセージをプロパティファイルから取得
+			String dbErrorMsg = MessageManager.getMessage(messageSource, ErrorMessage.DATA_ACCESS_ERROR_MESSAGE);
+			// DB情報取得エラー時のメッセージをセット
+			model.addAttribute("dbErrorMsg", dbErrorMsg);
+		} catch (Exception e) {
+			/*			//メッセージ・プロパティにまとめるためコメント化
+						// DB情報取得エラー時のメッセージをセット
+						String dbErrorMsg = "予期せぬエラーが発生しました。管理者へ問い合わせください。(エラーコード：1)";
+			*/
+			// エラーメッセージをプロパティファイルから取得
+			String dbErrorMsg = MessageManager.getMessage(messageSource, ErrorMessage.ALL_ERROR_MESSAGE);
+			// DB情報取得エラー時のメッセージをセット
+			model.addAttribute("dbErrorMsg", dbErrorMsg);
+		}
+
+		return "admin/categoryInfoControl/index";
+	}
+
+	/**
+	 * 全分類情報を取得
+	 * 
+	 * @param model
+	 * @param form
+	 */
+	public void getCategoryInfoList(Model model) {
+		// 分類情報画面に表示するデータを取得
+		List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData();
+		// 分類一覧情報をセット
+		model.addAttribute("categoryInfoList", categoryInfoList);
+	}
+
+	public void testDataAccessException() throws DataAccessException {
+		// データベース操作 
+		throw new DataAccessException("データベース操作中にエラーが発生しました") {
+		};
+	}
+
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CenterInfoController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CenterInfoController.java
@@ -2,18 +2,25 @@ package com.digitalojt.web.controller;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import com.digitalojt.web.consts.ErrorMessage;
 import com.digitalojt.web.consts.Region;
+import com.digitalojt.web.consts.ResultMessage;
 import com.digitalojt.web.consts.UrlConsts;
 import com.digitalojt.web.entity.CenterInfo;
 import com.digitalojt.web.form.CenterInfoForm;
+import com.digitalojt.web.form.RegisterCenterInfoForm;
+import com.digitalojt.web.form.UpdateCenterInfoForm;
 import com.digitalojt.web.service.CenterInfoService;
 import com.digitalojt.web.util.MessageManager;
 
@@ -23,7 +30,7 @@ import lombok.RequiredArgsConstructor;
 /**
  * 在庫センター情報画面のコントローラークラス
  * 
- * @author your name
+ * @author Okuma
  *
  */
 @Controller
@@ -57,7 +64,7 @@ public class CenterInfoController {
 		// 都道府県プルダウン情報をセット
 		model.addAttribute("regions", regions);
 
-		return "admin/centerInfo/index";
+		return UrlConsts.CENTER_INFO_INDEX;
 	}
 
 	/**
@@ -65,6 +72,7 @@ public class CenterInfoController {
 	 * 
 	 * @param model
 	 * @param form
+	 * @param bindingResult
 	 * @return
 	 */
 	@PostMapping(UrlConsts.CENTER_INFO_SEARCH)
@@ -72,9 +80,10 @@ public class CenterInfoController {
 
 		// Valid項目チェック
 		if (bindingResult.hasErrors()) {
-			
+
 			// エラーメッセージをプロパティファイルから取得
-			String errorMsg = MessageManager.getMessage(messageSource, bindingResult.getGlobalError().getDefaultMessage());
+			String errorMsg = MessageManager.getMessage(messageSource,
+					bindingResult.getGlobalError().getDefaultMessage());
 			model.addAttribute("errorMsg", errorMsg);
 
 			// 都道府県Enumをリストに変換
@@ -83,7 +92,7 @@ public class CenterInfoController {
 			// 都道府県プルダウン情報をセット
 			model.addAttribute("regions", regions);
 
-			return "admin/centerInfo/index";
+			return UrlConsts.CENTER_INFO_INDEX;
 		}
 
 		// 在庫センター情報画面に表示するデータを取得
@@ -98,6 +107,137 @@ public class CenterInfoController {
 		// 都道府県プルダウン情報をセット
 		model.addAttribute("regions", regions);
 
-		return "admin/centerInfo/index";
+		return UrlConsts.CENTER_INFO_INDEX;
+	}
+
+	/**
+	 * 登録入力画面表示
+	 * 
+	 * @param model
+	 * @return
+	 */
+	@GetMapping(UrlConsts.CENTER_INFO_REGISTER)
+	public String register(Model model) {
+
+		return UrlConsts.CENTER_INFO_REGISTER;
+	}
+
+	/**
+	 * 登録結果表示
+	 * 
+	 * @param form
+	 * @param bindingResult
+	 * @param redirectAttributes
+	 * @return
+	 */
+	@PostMapping(UrlConsts.CENTER_INFO_REGISTRATION_COMPLETED)
+	public String register(@Valid RegisterCenterInfoForm form, BindingResult bindingResult,
+			RedirectAttributes redirectAttributes) {
+		// Valid項目チェック
+		if (bindingResult.hasErrors()) {
+
+			// エラーメッセージをプロパティファイルから取得しフラッシュ属性として設定
+			String errorMsg = MessageManager.getMessage(messageSource,
+					bindingResult.getGlobalError().getDefaultMessage());
+			redirectAttributes.addFlashAttribute("errorMsg", errorMsg);
+
+			return "redirect:" + UrlConsts.CENTER_INFO_REGISTER;
+		}
+
+		// 在庫センター情報を登録
+		try {
+			centerInfoService.registerCenterInfo(form);
+		} catch (Exception e) {
+			// エラーメッセージをフラッシュ属性として設定
+			String errorMsg = messageSource.getMessage(ResultMessage.REGISTRATION_ERROR, null,
+					Locale.getDefault());
+			redirectAttributes.addFlashAttribute("errorMsg", errorMsg);
+
+			// 初期表示にリダイレクト
+			return "redirect:" + UrlConsts.CENTER_INFO;
+		}
+
+		// 登録完了メッセージをフラッシュ属性として設定
+		String completedMsg = messageSource.getMessage(ResultMessage.REGISTRATION_COMPLETED, null,
+				Locale.getDefault());
+		redirectAttributes.addFlashAttribute("completedMsg", completedMsg);
+
+		// 初期表示にリダイレクト
+		return "redirect:" + UrlConsts.CENTER_INFO;
+	}
+
+	/**
+	 * センター情報詳細（更新/削除）画面表示
+	 * 
+	 * @param centerId
+	 * @param model
+	 * @param redirectAttributes
+	 * @return
+	 */
+	@GetMapping(UrlConsts.CENTER_INFO_DETAILS)
+	public String details(@PathVariable int centerId, Model model, RedirectAttributes redirectAttributes) {
+
+		// 在庫センター情報詳細（更新/削除）画面に表示するデータを取得
+		List<CenterInfo> centerInfoList = centerInfoService.getCenterInfoData(centerId);
+
+		if (!centerInfoList.isEmpty()) {
+			// 在庫センター情報詳細をセット
+			model.addAttribute("centerInfoList", centerInfoList);
+
+			return UrlConsts.CENTER_INFO_UPDATE;
+		} else {
+			// エラーメッセージをプロパティファイルから取得
+			String errorMsg = messageSource.getMessage(ErrorMessage.NULL_CENTER_ID_MESSAGE, null,
+					Locale.getDefault());
+			redirectAttributes.addFlashAttribute("errorMsg", errorMsg);
+
+			// 初期表示にリダイレクト
+			return "redirect:" + UrlConsts.CENTER_INFO;
+		}
+	}
+
+	/**
+	 * 更新結果を表示
+	 * 
+	 * @param form
+	 * @param bindingResult
+	 * @param redirectAttributes
+	 * @return
+	 */
+	@PostMapping(UrlConsts.CENTER_INFO_UPDATE)
+	public String update(@Valid UpdateCenterInfoForm form, BindingResult bindingResult,
+			RedirectAttributes redirectAttributes) {
+
+		// Valid項目チェック
+		if (bindingResult.hasErrors()) {
+
+			// エラーメッセージをプロパティファイルから取得しフラッシュ属性として設定	
+			String errorMsg = MessageManager.getMessage(messageSource,
+					bindingResult.getGlobalError().getDefaultMessage());
+			redirectAttributes.addFlashAttribute("errorMsg", errorMsg);
+
+			return "redirect:/admin/centerInfo/details/" + form.getCenterId();
+		}
+
+		// 在庫センター情報を登録
+		try {
+			centerInfoService.updateCenterInfo(form);
+		} catch (Exception e) {
+			// エラーメッセージをフラッシュ属性として設定
+			String errorMsg = messageSource.getMessage(ResultMessage.UPDATE_ERROR, null,
+					Locale.getDefault());
+			redirectAttributes.addFlashAttribute("errorMsg", errorMsg);
+
+			// 初期表示にリダイレクト
+			return "redirect:" + UrlConsts.CENTER_INFO;
+		}
+
+		// 登録完了メッセージをフラッシュ属性として設定
+		String completedMsg = messageSource.getMessage(ResultMessage.UPDATE_COMPLETED, null,
+				Locale.getDefault());
+		redirectAttributes.addFlashAttribute("completedMsg", completedMsg);
+
+		// 初期表示にリダイレクト
+		return "redirect:" + UrlConsts.CENTER_INFO;
 	}
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/LoginController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/LoginController.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 /**
  * ログイン画面のコントローラークラス
  * 
- * @author your name
+ * @author Okuma
  *
  */
 @Controller

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/StockListController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/StockListController.java
@@ -1,18 +1,45 @@
 package com.digitalojt.web.controller;
 
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
+import java.util.Arrays;
+import java.util.List;
 
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import com.digitalojt.web.consts.RangeType;
 import com.digitalojt.web.consts.UrlConsts;
+import com.digitalojt.web.entity.CategoryInfo;
+import com.digitalojt.web.entity.StockInfo;
+import com.digitalojt.web.form.StockInfoForm;
+import com.digitalojt.web.service.CategoryInfoService;
+import com.digitalojt.web.service.StockInfoService;
+import com.digitalojt.web.util.MessageManager;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 /**
  * 在庫一覧画面コントローラークラス
  * 
- * @author your name
+ * @author Okuma
  *
  */
 @Controller
+@RequiredArgsConstructor
 public class StockListController extends AbstractController {
+
+	/** 在庫一覧 サービス */
+	private final StockInfoService stockInfoService;
+
+	/** 分類情報 サービス */
+	private final CategoryInfoService categoryInfoService;
+
+	/** メッセージソース */
+	private final MessageSource messageSource;
 
 	/**
 	 * 初期表示
@@ -20,8 +47,97 @@ public class StockListController extends AbstractController {
 	 * @return String(path)
 	 */
 	@GetMapping(UrlConsts.STOCK_LIST)
-	public String index() {
+	public String index(Model model) {
 
-		return "admin/stockList/index";
+		// 在庫一覧画面に表示するデータを取得
+		List<StockInfo> stockInfoList = stockInfoService.getStockInfoData();
+
+		// 画面表示用に情報リストをセット
+		model.addAttribute("stockInfoList", stockInfoList);
+
+		// プルダウン用の分類一覧情報をセット
+		setCategoryInfoList(model);
+
+		// 検索範囲の条件(以上・以下）プルダウン情報をセット
+		setRangeTypes(model);
+
+		return UrlConsts.STOCK_LIST_INDEX;
+	}
+
+	/**	
+	 * 検索結果表示
+	 * 
+	 * @param model
+	 * @param form
+	 * @return
+	 */
+	@PostMapping(UrlConsts.STOCK_LIST_SEARCH)
+	public String search(Model model, @Valid StockInfoForm form, BindingResult bindingResult) {
+
+		// Valid項目チェック
+		if (bindingResult.hasErrors()) {
+
+			// エラーメッセージをプロパティファイルから取得
+			String errorMsg = MessageManager.getMessage(messageSource,
+					bindingResult.getGlobalError().getDefaultMessage());
+			model.addAttribute("errorMsg", errorMsg);
+
+			// プルダウン用の分類一覧情報をセット
+			setCategoryInfoList(model);
+
+			// 検索範囲の条件(以上・以下）プルダウン情報をセット
+			setRangeTypes(model);
+
+			return UrlConsts.STOCK_LIST_INDEX;
+		}
+
+		// 在庫一覧画面に表示するデータを取得
+		List<StockInfo> stockInfoList = stockInfoService.getStockInfoData(form.getCategoryId(), form.getName(),
+				form.getAmount(), form.getRange());
+
+		// 画面表示用に商品情報リストをセット
+		model.addAttribute("stockInfoList", stockInfoList);
+
+		// プルダウン用の分類一覧情報をセット
+		setCategoryInfoList(model);
+
+		// 検索範囲の条件(以上・以下）プルダウン情報をセット
+		setRangeTypes(model);
+
+		return UrlConsts.STOCK_LIST_INDEX;
+
+	}
+
+	/**
+	 * 分類名プルダウン情報をセット
+	 * 
+	 * @param model
+	 * 
+	 */
+	public void setCategoryInfoList(Model model) {
+
+		// プルダウン用に分類名を取得しリストに変換
+		List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData();
+
+		// プルダウン用の分類一覧情報をセット
+		model.addAttribute("categoryInfoList", categoryInfoList);
+
+	}
+
+	/**
+	 * 検索範囲の条件(以上・以下）プルダウン情報を
+	 * 検索範囲の条件(以上・以下）Enumから取得しセット
+	 * 
+	 * @param model
+	 * 
+	 */
+	public void setRangeTypes(Model model) {
+
+		// 検索範囲の条件(以上・以下）Enumをリストに変換
+		List<RangeType> rangeTypes = Arrays.asList(RangeType.values());
+
+		// 検索範囲の条件(以上・以下）プルダウン情報をセット
+		model.addAttribute("rangeType", rangeTypes);
+
 	}
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/entity/AdminInfo.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/entity/AdminInfo.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 /**
  * 管理者情報Entity
  * 
- * @author your name
+ * @author Okuma
  *
  */
 @Data

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/entity/CategoryInfo.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/entity/CategoryInfo.java
@@ -1,0 +1,49 @@
+package com.digitalojt.web.entity;
+
+import java.sql.Timestamp;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 分類情報Entity
+ * 
+ * @author Okuma
+ *
+ */
+
+@Data
+@Getter
+@Setter
+@Entity
+public class CategoryInfo {
+
+	/**
+	 * 分類ID
+	 */
+	@Id
+	private Integer categoryId;
+
+	/**
+	 * 分類名
+	 */
+	private String categoryName;
+
+	/**
+	 * 論理削除フラグ
+	 */
+	private String deleteFlag;
+
+	/**
+	 * 更新日
+	 */
+	private Timestamp updateDate;
+
+	/**
+	 * 登録日
+	 */
+	private Timestamp createDate;
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/entity/CenterInfo.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/entity/CenterInfo.java
@@ -2,8 +2,13 @@ package com.digitalojt.web.entity;
 
 import java.sql.Timestamp;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,7 +16,7 @@ import lombok.Setter;
 /**
  * センター情報Entity
  * 
- * @author your name
+ * @author Okuma
  *
  */
 @Data
@@ -23,44 +28,55 @@ public class CenterInfo {
 	/**
 	 * センターID
 	 */
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Id
 	private int centerId;
-	
+
 	/**
 	 * センター名
 	 */
 	private String centerName;
-	
+
+	/**
+	 * 郵便番号
+	 */
+	private String postCode;
+
 	/**
 	 * 住所
 	 */
 	private String address;
-	
+
 	/**
 	 * 電話番号
 	 */
 	private String phoneNumber;
-	
+
 	/**
 	 * 管理者名
 	 */
 	private String managerName;
-	
+
 	/**
 	 * 未使用フラグ
 	 */
 	private int operationalStatus;
-	
+
 	/**
 	 * 最大容量
 	 */
 	private String maxStorageCapacity;
-	
+
 	/**
 	 * 現在容量
 	 */
 	private String currentStorageCapacity;
-	
+
+	/**
+	 *　備考
+	 */
+	private String notes;
+
 	/**
 	 * 論理削除フラグ
 	 */
@@ -74,5 +90,28 @@ public class CenterInfo {
 	/**
 	 * 登録日
 	 */
+	@Column(updatable = false)
 	private Timestamp createDate;
+
+	/**
+	 * 新規登録時に呼び出されるメソッド
+	 * エンティティの作成日時および更新日時を設定し、
+	 * 削除フラグのデフォルト値を設定
+	 */
+	@PrePersist
+	protected void onCreate() {
+		Timestamp now = new Timestamp(System.currentTimeMillis());
+		createDate = now;
+		updateDate = now;
+		deleteFlag = "0"; // デフォルト値を設定
+	}
+
+	/**
+	 * 更新時に呼び出されるメソッド
+	 * エンティティの更新日時を現在の日時に設定
+	 */
+	@PreUpdate
+	protected void onUpdate() {
+		updateDate = new Timestamp(System.currentTimeMillis());
+	}
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/entity/StockInfo.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/entity/StockInfo.java
@@ -1,0 +1,81 @@
+package com.digitalojt.web.entity;
+
+import java.sql.Timestamp;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Data;
+
+/**
+ * 在庫情報Entity
+ * 
+ * @author Okuma
+ *
+ */
+@Data
+@Entity
+public class StockInfo {
+	/**
+	 * 在庫ID
+	 */
+	@Id
+	private int stockId;
+
+	/**
+	 * 分類ID
+	 */
+	@ManyToOne
+	@JoinColumn(name = "categoryId")
+	private CategoryInfo categoryInfo;
+
+	/**
+	 * 在庫名
+	 */
+	private String name;
+
+	/**
+	 * センターID
+	 */
+	@ManyToOne
+	@JoinColumn(name = "centerId")
+	private CenterInfo centerInfo;
+
+	/**
+	 * 説明
+	 */
+	private String description;
+
+	/**
+	 * 個数
+	 */
+	private Integer amount;
+
+	/**
+	 * 論理削除フラグ
+	 */
+	private int deleteFlag;
+
+	/**
+	 * 更新日
+	 */
+	private Timestamp updateDate;
+
+	/**
+	 * 登録日
+	 */
+	private Timestamp createDate;
+
+	public String getCategoryName() {
+		return categoryInfo != null ? categoryInfo.getCategoryName() : null;
+	}
+
+	public Integer getCategoryId() {
+		return categoryInfo != null ? categoryInfo.getCategoryId() : null;
+	}
+
+	public String getCenterName() {
+		return centerInfo != null ? centerInfo.getCenterName() : null;
+	}
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/form/CategoryInfoControlForm.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/form/CategoryInfoControlForm.java
@@ -1,0 +1,43 @@
+package com.digitalojt.web.form;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.digitalojt.web.consts.CategoryConsts;
+import com.digitalojt.web.validation.CategoryInfoControlFormValidator;
+
+import lombok.Data;
+
+/**
+ * 分類情報管理画面のフォームクラス
+ * 
+ * @author Okuma
+ *
+ */
+@Data
+@CategoryInfoControlFormValidator
+public class CategoryInfoControlForm {
+
+	/**
+	 * 分類名
+	 */
+	private String category;
+
+	/**
+	 * 引数に合致する分類情報を取得
+	 * 
+	 * @param category
+	 * @return
+	 */
+	public List<CategoryConsts> getCategoryResearchResult(String category) {
+
+		List<CategoryConsts> categoryResearchResult = new ArrayList<>();
+		for (CategoryConsts CategoryConsts : CategoryConsts.values()) {
+			if (CategoryConsts.getCategory().equals(category)) {
+				categoryResearchResult.add(CategoryConsts);
+			}
+		}
+		return categoryResearchResult;
+	}
+
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/form/CenterInfoForm.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/form/CenterInfoForm.java
@@ -7,7 +7,7 @@ import lombok.Data;
 /**
  * 在庫センター情報画面のフォームクラス
  * 
- * @author your name
+ * @author Okuma
  *
  */
 @Data

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/form/LoginForm.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/form/LoginForm.java
@@ -5,7 +5,7 @@ import lombok.Data;
 /**
  * ログイン画面のフォームクラス
  * 
- * @author your name
+ * @author Okuma
  *
  */
 @Data

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/form/RegisterCenterInfoForm.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/form/RegisterCenterInfoForm.java
@@ -1,0 +1,62 @@
+package com.digitalojt.web.form;
+
+import com.digitalojt.web.validation.RegisterCenterInfoFormValidator;
+
+import lombok.Data;
+
+/**
+ * 在庫センター情報登録画面のフォームクラス
+ * 
+ * @author Okuma
+ *
+ */
+@Data
+@RegisterCenterInfoFormValidator
+public class RegisterCenterInfoForm {
+
+	/**
+	 * センター名
+	 */
+	private String centerName;
+
+	/**
+	 * 郵便番号
+	 */
+	private String postCode;
+
+	/**
+	 * 住所
+	 */
+	private String address;
+
+	/**
+	 * 電話番号
+	 */
+	private String phoneNumber;
+
+	/**
+	 * 管理者名
+	 */
+	private String managerName;
+
+	/**
+	 * 稼働状況ステータス
+	 */
+	private int operationalStatus;
+
+	/**
+	 * 最大保管容量（m³）
+	 */
+	private String maxStorageCapacity;
+
+	/**
+	 * 現在保管容量（m³）
+	 */
+	private String currentStorageCapacity;
+
+	/**
+	 * 備考
+	 */
+	private String notes;
+
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/form/StockInfoForm.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/form/StockInfoForm.java
@@ -1,0 +1,37 @@
+package com.digitalojt.web.form;
+
+import com.digitalojt.web.validation.StockInfoFormValidator;
+
+import lombok.Data;
+
+/**
+ * 在庫一覧画面のフォームクラス
+ * 
+ * @author Okuma
+ *
+ */
+@Data
+@StockInfoFormValidator
+public class StockInfoForm {
+
+	/**
+	 * 分類ID
+	 */
+	private Integer categoryId;
+
+	/**
+	 * 在庫名
+	 */
+	private String name;
+
+	/**
+	 * 個数
+	 */
+	private Integer amount;
+
+	/**
+	 * 検索範囲の条件(以上・以下）
+	 */
+	private String range;
+
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/form/UpdateCenterInfoForm.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/form/UpdateCenterInfoForm.java
@@ -1,0 +1,71 @@
+package com.digitalojt.web.form;
+
+import com.digitalojt.web.validation.UpdateCenterInfoFormValidator;
+
+import lombok.Data;
+
+/**
+ * 在庫センター情報詳細（更新/削除）画面のフォームクラス
+ * 
+ * @author Okuma
+ *
+ */
+@Data
+@UpdateCenterInfoFormValidator
+public class UpdateCenterInfoForm {
+	/**
+	 * センターID
+	 */
+	private int centerId;
+
+	/**
+	 * センター名
+	 */
+	private String centerName;
+
+	/**
+	 * 郵便番号
+	 */
+	private String postCode;
+
+	/**
+	 * 住所
+	 */
+	private String address;
+
+	/**
+	 * 電話番号
+	 */
+	private String phoneNumber;
+
+	/**
+	 * 管理者名
+	 */
+	private String managerName;
+
+	/**
+	 * 稼働状況ステータス
+	 */
+	private int operationalStatus;
+
+	/**
+	 * 最大保管容量（m³）
+	 */
+	private String maxStorageCapacity;
+
+	/**
+	 * 現在保管容量（m³）
+	 */
+	private String currentStorageCapacity;
+
+	/**
+	 * 備考
+	 */
+	private String notes;
+
+	/**
+	 * 論理削除フラグ
+	 */
+	private String deleteFlag;
+
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/AdminInfoRepository.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/AdminInfoRepository.java
@@ -8,7 +8,7 @@ import com.digitalojt.web.entity.AdminInfo;
 /**
  * 管理者情報テーブルリポジトリー
  *
- * @author your name
+ * @author Okuma
  * 
  */
 @Repository

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CategoryInfoRepository.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CategoryInfoRepository.java
@@ -1,0 +1,37 @@
+package com.digitalojt.web.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.digitalojt.web.entity.CategoryInfo;
+
+/**
+ * 分類情報テーブルリポジトリー
+ *
+ * @author Okuma
+ * 
+ */
+@Repository
+public interface CategoryInfoRepository extends JpaRepository<CategoryInfo, Integer> {
+
+	/**
+	 * 削除フラグが「0」の分類情報を取得
+	 * 
+	 * @return
+	 */
+	@Query("SELECT s FROM CategoryInfo s WHERE s.deleteFlag = '0' ORDER BY categoryId ASC")
+	List<CategoryInfo> findAllActive();
+
+	
+	/**
+	 * 引数に合致する分類情報を取得
+	 * 
+	 * @param categoryName
+	 * @return paramで検索した結果
+	 */
+	@Query("SELECT s FROM CategoryInfo s WHERE s.categoryName = :categoryName")
+	List<CategoryInfo> findByCategoryName(String categoryName);
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CenterInfoRepository.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CenterInfoRepository.java
@@ -11,7 +11,7 @@ import com.digitalojt.web.entity.CenterInfo;
 /**
  * センター情報テーブルリポジトリー
  *
- * @author your name
+ * @author Okuma
  * 
  */
 @Repository
@@ -31,4 +31,13 @@ public interface CenterInfoRepository extends JpaRepository<CenterInfo, Integer>
 	List<CenterInfo> findByCenterNameAndRegionAndStorageCapacity(
 			String centerName,
 			String region);
+
+	/**
+	 * センターIDに合致する在庫センター情報を取得
+	 * 
+	 * @param centerId
+	 * @return paramで検索した結果
+	 */
+
+	List<CenterInfo> findByCenterId(int centerId);
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/StockInfoRepository.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/StockInfoRepository.java
@@ -1,0 +1,49 @@
+package com.digitalojt.web.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.digitalojt.web.entity.StockInfo;
+
+/**
+ * 在庫情報テーブルリポジトリー
+ *
+ * @author Okuma
+ * 
+ */
+@Repository
+public interface StockInfoRepository extends JpaRepository<StockInfo, Integer> {
+
+	/**
+	 * 削除フラグが「0」の在庫情報を取得
+	 * 
+	 * @return
+	 */
+	@Query("SELECT s FROM StockInfo s WHERE s.deleteFlag = 0 ORDER BY stockId ASC")
+	List<StockInfo> findAllActive();
+
+	/**
+	 * 引数に合致する在庫情報を取得
+	 * 
+	 * @param categoryId
+	 * @param name   在庫名
+	 * @param amount 個数
+	 * @param range  以上か以下
+	 * @return paramで検索した結果
+	 */
+
+	@Query("SELECT s FROM StockInfo s WHERE " +
+			"(:categoryId IS NULL OR s.categoryInfo.categoryId = :categoryId) AND " +
+			"(:name = '' OR s.name LIKE %:name%) AND " +
+			"(:amount IS NULL OR (:range = 'OVER' AND s.amount >= :amount) OR (:range = 'UNDER' AND s.amount <= :amount)) AND "
+			+
+			"(s.deleteFlag = 0)")
+	List<StockInfo> findByCategoryInfoCategoryIdAndNameAndAmount(
+			Integer categoryId,
+			String name,
+			Integer amount,
+			String range);
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CategoryInfoService.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CategoryInfoService.java
@@ -1,0 +1,55 @@
+package com.digitalojt.web.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.digitalojt.web.entity.CategoryInfo;
+import com.digitalojt.web.repository.CategoryInfoRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 分類情報画面のサービスクラス
+ *
+ * @author Okuma
+ * 
+ */
+@Service
+@RequiredArgsConstructor
+public class CategoryInfoService {
+
+	/** 分類情報テーブル リポジトリー */
+	private final CategoryInfoRepository repository;
+
+	/**
+	 * 分類情報を全件検索で取得
+	 * 
+	 * @return
+	 */
+	public List<CategoryInfo> getCategoryInfoData() {
+
+		return repository.findAll();
+	}
+	
+	/**
+	 * 分類情報をを全件検索で取得（削除フラグ「0」のみ)
+	 * 
+	 * @return
+	 */
+	public List<CategoryInfo> getCategoryInfoDataActive() {
+		return repository.findAllActive();
+	}
+	
+	/**
+	 * 引数に合致する分類情報を取得
+	 * 
+	 * @param categoryName
+	 * @return
+	 */
+	public List<CategoryInfo> getCategoryInfoData(String categoryName) {
+
+		return repository.findByCategoryName(categoryName);
+	}
+
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CenterInfoService.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CenterInfoService.java
@@ -3,8 +3,11 @@ package com.digitalojt.web.service;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.digitalojt.web.entity.CenterInfo;
+import com.digitalojt.web.form.RegisterCenterInfoForm;
+import com.digitalojt.web.form.UpdateCenterInfoForm;
 import com.digitalojt.web.repository.CenterInfoRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -12,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 /**
  * 在庫センター情報画面のサービスクラス
  *
- * @author your name
+ * @author Okuma
  * 
  */
 @Service
@@ -42,5 +45,61 @@ public class CenterInfoService {
 	 */
 	public List<CenterInfo> getCenterInfoData(String centerName, String region) {
 		return repository.findByCenterNameAndRegionAndStorageCapacity(centerName, region);
+	}
+
+	/**
+	 * 在庫センター情報を登録
+	 * 
+	 * @param form
+	 */
+	@Transactional(rollbackForClassName = { "Exception" })
+	public void registerCenterInfo(RegisterCenterInfoForm form) {
+		// 在庫センター情報を登録するためのCenterInfoオブジェクトを作成
+		CenterInfo centerInfo = new CenterInfo();
+		centerInfo.setCenterName(form.getCenterName());
+		centerInfo.setPostCode(form.getPostCode());
+		centerInfo.setAddress(form.getAddress());
+		centerInfo.setPhoneNumber(form.getPhoneNumber());
+		centerInfo.setManagerName(form.getManagerName());
+		centerInfo.setOperationalStatus(form.getOperationalStatus());
+		centerInfo.setMaxStorageCapacity(form.getMaxStorageCapacity());
+		centerInfo.setCurrentStorageCapacity(form.getCurrentStorageCapacity());
+		centerInfo.setNotes(form.getNotes());
+
+		repository.save(centerInfo);
+	}
+
+	/**
+	 * センターIDに合致する在庫センター情報を取得
+	 * 
+	 * @param centerId
+	 * @return
+	 */
+	public List<CenterInfo> getCenterInfoData(int centerId) {
+		return repository.findByCenterId(centerId);
+	}
+
+	/**
+	 * センターIDに合致する在庫センター情報を更新
+	 * 
+	 * @param form
+	 */
+	@Transactional(rollbackForClassName = { "Exception" })
+	public void updateCenterInfo(UpdateCenterInfoForm form) {
+		// 在庫センター情報を更新するためのCenterInfoオブジェクトを作成
+		CenterInfo centerInfo = new CenterInfo();
+		centerInfo.setCenterId(form.getCenterId());
+		centerInfo.setDeleteFlag(form.getDeleteFlag());
+		centerInfo.setCenterName(form.getCenterName());
+		centerInfo.setPostCode(form.getPostCode());
+		centerInfo.setAddress(form.getAddress());
+		centerInfo.setPhoneNumber(form.getPhoneNumber());
+		centerInfo.setManagerName(form.getManagerName());
+		centerInfo.setOperationalStatus(form.getOperationalStatus());
+		centerInfo.setMaxStorageCapacity(form.getMaxStorageCapacity());
+		centerInfo.setCurrentStorageCapacity(form.getCurrentStorageCapacity());
+		centerInfo.setNotes(form.getNotes());
+
+		repository.save(centerInfo);
 	}
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/service/LoginService.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/service/LoginService.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 /**
  * ログイン画面のサービスクラス
  *
- * @author your name
+ * @author Okuma
  * 
  */
 @Service

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/service/StockInfoService.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/service/StockInfoService.java
@@ -1,0 +1,47 @@
+package com.digitalojt.web.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.digitalojt.web.entity.StockInfo;
+import com.digitalojt.web.repository.StockInfoRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 在庫一覧画面のサービスクラス
+ *
+ * @author Okuma
+ * 
+ */
+@Service
+@RequiredArgsConstructor
+public class StockInfoService {
+
+	/** センター情報テーブル リポジトリー */
+	private final StockInfoRepository repository;
+
+	/**
+	 * 在庫センター情報を全件検索で取得（削除フラグ「0」のみ)
+	 * 
+	 * @return
+	 */
+	public List<StockInfo> getStockInfoData() {
+		return repository.findAllActive();
+	}
+
+	/**
+	 * 引数に合致する在庫情報を取得
+	 * 
+	 * @param categoryId
+	 * @param name 
+	 * @param amount
+	 * @param range
+	 * @return 
+	 * 
+	 */
+	public List<StockInfo> getStockInfoData(Integer categoryId, String name, Integer amount, String range) {
+		return repository.findByCategoryInfoCategoryIdAndNameAndAmount(categoryId, name, amount, range);
+	}
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/util/MessageManager.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/util/MessageManager.java
@@ -1,3 +1,4 @@
+
 package com.digitalojt.web.util;
 
 import java.util.Locale;
@@ -7,7 +8,7 @@ import org.springframework.context.MessageSource;
 /**
  * メッセージ管理 共通クラス
  * 
- * @author your name
+ * @author Okuma
  */
 public class MessageManager {
 
@@ -20,6 +21,6 @@ public class MessageManager {
 	 * @return 
 	 */
 	public static String getMessage(MessageSource messageSource, String key, Object... params) {
-		return messageSource.getMessage(key,  params, Locale.JAPAN);
+		return messageSource.getMessage(key, params, Locale.JAPAN);
 	}
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/util/ParmCheckUtil.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/util/ParmCheckUtil.java
@@ -7,7 +7,7 @@ import com.digitalojt.web.consts.InvalidCharacter;
 /**
  * パラメーターチェックに関する処理を行うクラス
  * 
- * @author your name
+ * @author Okuma
  *
  */
 public class ParmCheckUtil {
@@ -21,6 +21,6 @@ public class ParmCheckUtil {
 	public static Boolean isParameterInvalid(String val) {
 
 		return Arrays.stream(InvalidCharacter.values())
-                .anyMatch(invalidChar -> val.indexOf(invalidChar.getCharacter()) >= 0);
+				.anyMatch(invalidChar -> val.indexOf(invalidChar.getCharacter()) >= 0);
 	}
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoControlFormValidator.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoControlFormValidator.java
@@ -11,14 +11,14 @@ import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 
 /**
- * 在庫センター情報画面のバリデーションチェック インターフェース
+ * 分類情報管理画面のバリデーションチェック インターフェース
  * 
  * @author Okuma
  */
-@Constraint(validatedBy = CenterInfoFormValidatorImpl.class)
+@Constraint(validatedBy = CategoryInfoControlFormValidatorImpl.class)
 @Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
-public @interface CenterInfoFormValidator {
+public @interface CategoryInfoControlFormValidator {
 
 	String message() default ErrorMessage.ALL_FIELDS_EMPTY_ERROR_MESSAGE;
 

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoControlFormValidatorImpl.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoControlFormValidatorImpl.java
@@ -1,0 +1,62 @@
+package com.digitalojt.web.validation;
+
+import org.thymeleaf.util.StringUtils;
+
+import com.digitalojt.web.consts.ErrorMessage;
+import com.digitalojt.web.consts.ParamsLimits;
+import com.digitalojt.web.form.CategoryInfoControlForm;
+import com.digitalojt.web.util.ParmCheckUtil;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * 分類情報管理画面のバリデーションチェック 実装クラス
+ * 
+ * @author Okuma
+ */
+public class CategoryInfoControlFormValidatorImpl implements ConstraintValidator<CategoryInfoControlFormValidator, CategoryInfoControlForm>  {
+
+	/**
+	 * バリデーションチェック
+	 */
+	@Override
+	public boolean isValid(CategoryInfoControlForm form, ConstraintValidatorContext context) {
+
+		// 最大文字数
+		int MAX_LENGTH = ParamsLimits.CATEGORY_MAX_LENGTH;
+
+		boolean allFieldsEmpty = StringUtils.isEmpty(form.getCategory());
+
+		// 分類名フィールドが空かをチェック
+		if (allFieldsEmpty) {
+			context.disableDefaultConstraintViolation();
+			context.buildConstraintViolationWithTemplate(ErrorMessage.CATEGORY_FIELDS_EMPTY_ERROR_MESSAGE)
+					.addConstraintViolation();
+			return false;
+		}
+
+		// 分類名のチェック
+		if (form.getCategory() != null) {
+
+			// 不正文字列チェック
+			if (ParmCheckUtil.isParameterInvalid(form.getCategory())) {
+				context.disableDefaultConstraintViolation();
+				context.buildConstraintViolationWithTemplate(ErrorMessage.INVALID_INPUT_ERROR_MESSAGE)
+						.addConstraintViolation();
+				return false;
+			}
+
+			// 文字数チェック
+			if (form.getCategory().length() > MAX_LENGTH) {
+				context.disableDefaultConstraintViolation();
+				context.buildConstraintViolationWithTemplate(ErrorMessage.CATEGORY_LENGTH_ERROR_MESSAGE)
+						.addConstraintViolation();
+				return false;
+			}
+		}
+
+		// その他のバリデーションに問題なければtrueを返す
+		return true;
+	}
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CenterInfoFormValidatorImpl.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CenterInfoFormValidatorImpl.java
@@ -3,6 +3,7 @@ package com.digitalojt.web.validation;
 import org.thymeleaf.util.StringUtils;
 
 import com.digitalojt.web.consts.ErrorMessage;
+import com.digitalojt.web.consts.ParamsLimits;
 import com.digitalojt.web.form.CenterInfoForm;
 import com.digitalojt.web.util.ParmCheckUtil;
 
@@ -12,7 +13,7 @@ import jakarta.validation.ConstraintValidatorContext;
 /**
  * 在庫センター情報画面のバリデーションチェック 実装クラス
  * 
- * @author your name
+ * @author Okuma
  */
 public class CenterInfoFormValidatorImpl implements ConstraintValidator<CenterInfoFormValidator, CenterInfoForm> {
 
@@ -23,7 +24,7 @@ public class CenterInfoFormValidatorImpl implements ConstraintValidator<CenterIn
 	public boolean isValid(CenterInfoForm form, ConstraintValidatorContext context) {
 
 		// 最大文字数
-		final int MAX_LENGTH = 20;
+		int MAX_LENGTH = ParamsLimits.CENTER_INFO_MAX_LENGTH;
 
 		boolean allFieldsEmpty = StringUtils.isEmpty(form.getCenterName()) &&
 				StringUtils.isEmpty(form.getRegion());
@@ -48,10 +49,6 @@ public class CenterInfoFormValidatorImpl implements ConstraintValidator<CenterIn
 			}
 
 			// 文字数チェック
-			/**
-			 *  TODO:Formクラスをシンプルにしたく、@Sizeを使わずこちらで桁数チェックを行いました。
-			 *  	 車輪の再発明なので、しないほうがいいでしょうか？
-			 */
 			if (form.getCenterName().length() > MAX_LENGTH) {
 				context.disableDefaultConstraintViolation();
 				context.buildConstraintViolationWithTemplate(ErrorMessage.CENTER_NAME_LENGTH_ERROR_MESSAGE)

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/RegisterCenterInfoFormValidator.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/RegisterCenterInfoFormValidator.java
@@ -11,14 +11,14 @@ import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 
 /**
- * 在庫センター情報画面のバリデーションチェック インターフェース
+ * 在庫センター情報登録画面のバリデーションチェック インターフェース
  * 
  * @author Okuma
  */
-@Constraint(validatedBy = CenterInfoFormValidatorImpl.class)
+@Constraint(validatedBy = RegisterCenterInfoFormValidatorImpl.class)
 @Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
-public @interface CenterInfoFormValidator {
+public @interface RegisterCenterInfoFormValidator {
 
 	String message() default ErrorMessage.ALL_FIELDS_EMPTY_ERROR_MESSAGE;
 

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/RegisterCenterInfoFormValidatorImpl.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/RegisterCenterInfoFormValidatorImpl.java
@@ -1,0 +1,137 @@
+package com.digitalojt.web.validation;
+
+import com.digitalojt.web.consts.ErrorMessage;
+import com.digitalojt.web.consts.OperationalStatus;
+import com.digitalojt.web.consts.ParamsLimits;
+import com.digitalojt.web.form.RegisterCenterInfoForm;
+import com.digitalojt.web.util.ParmCheckUtil;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * 在庫センター情報登録画面のバリデーションチェック 実装クラス
+ * 
+ * @author Okuma
+ */
+public class RegisterCenterInfoFormValidatorImpl
+		implements ConstraintValidator<RegisterCenterInfoFormValidator, RegisterCenterInfoForm> {
+
+	/**
+	 * バリデーションチェック
+	 */
+	@Override
+	public boolean isValid(RegisterCenterInfoForm form, ConstraintValidatorContext context) {
+
+		// すべてのフィールドが空かをチェック　　→不要　画面の機能で必須項目の入力をチェックしているため
+
+		// センター名のチェック
+		// 不正文字列チェック
+		if (ParmCheckUtil.isParameterInvalid(form.getCenterName())) {
+			setErrorMessage(context, ErrorMessage.INVALID_INPUT_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 文字数チェック
+		if (form.getCenterName().length() > ParamsLimits.CENTER_INFO_MAX_LENGTH) {
+			setErrorMessage(context, ErrorMessage.CENTER_NAME_LENGTH_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 郵便番号のチェック
+		// 正規表現によるフォーマットチェック
+		if (!form.getPostCode().matches(ParamsLimits.POST_CODE_FORMAT)) {
+			setErrorMessage(context, ErrorMessage.INVALID_POST_CODE_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 住所のチェック
+		// 不正文字列チェック
+		if (ParmCheckUtil.isParameterInvalid(form.getAddress())) {
+			setErrorMessage(context, ErrorMessage.INVALID_INPUT_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 文字数チェック
+		if (form.getAddress().length() > ParamsLimits.ADDRESS_MAX_LENGTH) {
+			setErrorMessage(context, ErrorMessage.ADDRESS_LENGTH_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 電話番号のチェック
+		// 正規表現によるフォーマットチェック
+
+		if (!form.getPhoneNumber().matches(ParamsLimits.PHONE_NUMBER_FORMAT)) {
+			setErrorMessage(context, ErrorMessage.INVALID_PHONE_NUMBER_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 管理者名のチェック
+		// 不正文字列チェック
+		if (ParmCheckUtil.isParameterInvalid(form.getManagerName())) {
+			setErrorMessage(context, ErrorMessage.INVALID_INPUT_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 文字数チェック
+		if (form.getManagerName().length() > ParamsLimits.MANAGER_NAME_MAX_LENGTH) {
+			setErrorMessage(context, ErrorMessage.MANAGER_NAME_LENGTH_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 稼働状況ステータスのチェック
+		if (form.getOperationalStatus() != OperationalStatus.ACTIVE.getType() &&
+				form.getOperationalStatus() != OperationalStatus.INACTIVE.getType()) {
+			setErrorMessage(context, ErrorMessage.UNEXPECTED_INPUT_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 最大保管容量（m³）のチェック
+		if (Integer.parseInt(form.getMaxStorageCapacity()) < ParamsLimits.MIN_STORAGE_CAPACITY
+				|| Integer.parseInt(form.getMaxStorageCapacity()) > ParamsLimits.MAX_STORAGE_CAPACITY) {
+			setErrorMessage(context, ErrorMessage.INVALID_MAX_STORAGE_CAPACITY_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 現在保管容量（m³）のチェック
+		if (Integer.parseInt(form.getCurrentStorageCapacity()) < ParamsLimits.MIN__CURRENT_STORAGE_CAPACITY) {
+			setErrorMessage(context, ErrorMessage.INVALID_CURRENT_STORAGE_CAPACITY_ERROR_MESSAGE);
+			return false;
+		} else if (Integer.parseInt(form.getCurrentStorageCapacity()) > Integer
+				.parseInt(form.getMaxStorageCapacity())) {
+			setErrorMessage(context, ErrorMessage.INVALID_CURRENT_STORAGE_CAPACITY_OVER_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 備考のチェック
+		// 不正文字列チェック
+		if (ParmCheckUtil.isParameterInvalid(form.getNotes())) {
+			setErrorMessage(context, ErrorMessage.INVALID_INPUT_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 文字数チェック
+		if (form.getNotes().length() > ParamsLimits.NOTES_MAX_LENGTH) {
+			setErrorMessage(context, ErrorMessage.NOTES_LENGTH_ERROR_MESSAGE);
+			return false;
+		}
+
+		// その他のバリデーションに問題なければtrueを返す
+		return true;
+	}
+
+	/**	
+	 * エラーメッセージを設定
+	 * 
+	 * @param context
+	 * @param errorMessage
+	 * 
+	 */
+	private void setErrorMessage(ConstraintValidatorContext context, String errorMessage) {
+		context.disableDefaultConstraintViolation();
+		context.buildConstraintViolationWithTemplate(errorMessage)
+				.addConstraintViolation();
+
+	}
+
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/StockInfoFormValidator.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/StockInfoFormValidator.java
@@ -11,14 +11,14 @@ import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 
 /**
- * 在庫センター情報画面のバリデーションチェック インターフェース
+ * 在庫一覧画面のバリデーションチェック インターフェース
  * 
  * @author Okuma
  */
-@Constraint(validatedBy = CenterInfoFormValidatorImpl.class)
+@Constraint(validatedBy = StockInfoFormValidatorImpl.class)
 @Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
-public @interface CenterInfoFormValidator {
+public @interface StockInfoFormValidator {
 
 	String message() default ErrorMessage.ALL_FIELDS_EMPTY_ERROR_MESSAGE;
 

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/StockInfoFormValidatorImpl.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/StockInfoFormValidatorImpl.java
@@ -1,0 +1,116 @@
+package com.digitalojt.web.validation;
+
+import org.thymeleaf.util.StringUtils;
+
+import com.digitalojt.web.consts.ErrorMessage;
+import com.digitalojt.web.consts.ParamsLimits;
+import com.digitalojt.web.consts.RangeType;
+import com.digitalojt.web.form.StockInfoForm;
+import com.digitalojt.web.util.ParmCheckUtil;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * 在庫一覧画面のバリデーションチェック 実装クラス
+ * 
+ * @author Okuma
+ */
+public class StockInfoFormValidatorImpl implements ConstraintValidator<StockInfoFormValidator, StockInfoForm> {
+	/**
+	 * バリデーションチェック
+	 */
+	@Override
+	public boolean isValid(StockInfoForm form, ConstraintValidatorContext context) {
+
+		//分類IDのチェック		
+		if (form.getCategoryId() != null) {
+
+			//最小数以上かつ最大数以下かチェック
+			if (ParamsLimits.CATEGORYID_MIN_NUM > form.getCategoryId()
+					|| ParamsLimits.CATEGORYID_MAX_NUM < form.getCategoryId()) {
+				setErrorMessage(context, ErrorMessage.CATEGORY_ID_MAXIMUM_LIMIT_ERROR_MESSAGE);
+				return false;
+			}
+		}
+
+		//在庫名のチェック
+		if (form.getName() != null) {
+
+			// 不正文字列チェック
+			if (ParmCheckUtil.isParameterInvalid(form.getName())) {
+				setErrorMessage(context, ErrorMessage.INVALID_INPUT_ERROR_MESSAGE);
+				return false;
+			}
+
+			// 文字数チェック
+			if (form.getName().length() > ParamsLimits.STOCK_NAME_MAX_LENGTH) {
+				setErrorMessage(context, ErrorMessage.STOCK_NAME_LENGTH_ERROR_MESSAGE);
+				return false;
+			}
+		}
+
+		//個数のチェック
+		if (form.getAmount() != null) {
+
+			//最小数以上かつ最大数以下かチェック
+			if (ParamsLimits.STOCK_MIN_NUM > form.getAmount() || ParamsLimits.STOCK_MAX_NUM < form.getAmount()) {
+				setErrorMessage(context, ErrorMessage.STOCK_NUM_INPUT_ERROR_MESSAGE);
+				return false;
+			}
+		}
+
+		//個数の検索の条件(以上・以下）のチェック
+		if (form.getRange() != null) {
+
+			// 不正文字列チェック
+			if (ParmCheckUtil.isParameterInvalid(form.getRange())) {
+				setErrorMessage(context, ErrorMessage.INVALID_INPUT_ERROR_MESSAGE);
+				return false;
+			}
+			//個数の検索の条件(以上・以下）かチェック
+			try {
+				RangeType.valueOf(form.getRange());
+			} catch (IllegalArgumentException e) {
+				// Enumにない値が入力された場合のエラーメッセージ設定
+				setErrorMessage(context, ErrorMessage.UNEXPECTED_INPUT_ERROR_MESSAGE);
+				return false;
+			}
+
+		}
+
+		//入力フィールドが全て空かをチェック
+
+		if (areAllFieldsEmpty(form)) {
+			setErrorMessage(context, ErrorMessage.ALL_FIELDS_EMPTY_ERROR_MESSAGE);
+			return false;
+		}
+
+		//その他のバリデーションに問題なければtrueを返す
+		return true;
+	}
+
+	/**	
+	 * 入力フィールド(分類・名称・個数)が全て空かをチェック
+	 * 
+	 * @param form
+	 * @return boolean
+	 * 
+	 */
+	private boolean areAllFieldsEmpty(StockInfoForm form) {
+		return form.getCategoryId() == null && StringUtils.isEmpty(form.getName()) && form.getAmount() == null;
+	}
+
+	/**	
+	 * エラーメッセージを設定
+	 * 
+	 * @param context
+	 * @param errorMessage
+	 * 
+	 */
+	private void setErrorMessage(ConstraintValidatorContext context, String errorMessage) {
+		context.disableDefaultConstraintViolation();
+		context.buildConstraintViolationWithTemplate(errorMessage)
+				.addConstraintViolation();
+	}
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/UpdateCenterInfoFormValidator.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/UpdateCenterInfoFormValidator.java
@@ -11,14 +11,14 @@ import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 
 /**
- * 在庫センター情報画面のバリデーションチェック インターフェース
+ * 在庫センター情報詳細（更新/削除）画面のバリデーションチェック インターフェース
  * 
  * @author Okuma
  */
-@Constraint(validatedBy = CenterInfoFormValidatorImpl.class)
+@Constraint(validatedBy = UpdateCenterInfoFormValidatorImpl.class)
 @Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
-public @interface CenterInfoFormValidator {
+public @interface UpdateCenterInfoFormValidator {
 
 	String message() default ErrorMessage.ALL_FIELDS_EMPTY_ERROR_MESSAGE;
 

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/UpdateCenterInfoFormValidatorImpl.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/UpdateCenterInfoFormValidatorImpl.java
@@ -1,0 +1,135 @@
+package com.digitalojt.web.validation;
+
+import com.digitalojt.web.consts.ErrorMessage;
+import com.digitalojt.web.consts.OperationalStatus;
+import com.digitalojt.web.consts.ParamsLimits;
+import com.digitalojt.web.form.UpdateCenterInfoForm;
+import com.digitalojt.web.util.ParmCheckUtil;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * 在庫センター情報詳細（更新/削除）画面のバリデーションチェック 実装クラス
+ * 
+ * @author Okuma
+ */
+public class UpdateCenterInfoFormValidatorImpl
+		implements ConstraintValidator<UpdateCenterInfoFormValidator, UpdateCenterInfoForm> {
+
+	/**
+	 * バリデーションチェック
+	 */
+	@Override
+	public boolean isValid(UpdateCenterInfoForm form, ConstraintValidatorContext context) {
+
+		// すべてのフィールドが空かをチェック　　→不要　画面の機能で必須項目の入力をチェックしているため
+
+		// センター名のチェック
+		// 不正文字列チェック
+		if (ParmCheckUtil.isParameterInvalid(form.getCenterName())) {
+			setErrorMessage(context, ErrorMessage.INVALID_INPUT_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 文字数チェック
+		if (form.getCenterName().length() > ParamsLimits.CENTER_INFO_MAX_LENGTH) {
+			setErrorMessage(context, ErrorMessage.CENTER_NAME_LENGTH_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 郵便番号のチェック
+		// 正規表現によるフォーマットチェック
+		if (!form.getPostCode().matches(ParamsLimits.POST_CODE_FORMAT)) {
+			setErrorMessage(context, ErrorMessage.INVALID_POST_CODE_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 住所のチェック
+		// 不正文字列チェック
+		if (ParmCheckUtil.isParameterInvalid(form.getAddress())) {
+			setErrorMessage(context, ErrorMessage.INVALID_INPUT_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 文字数チェック
+		if (form.getAddress().length() > ParamsLimits.ADDRESS_MAX_LENGTH) {
+			setErrorMessage(context, ErrorMessage.ADDRESS_LENGTH_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 電話番号のチェック
+		// 正規表現によるフォーマットチェック
+
+		if (!form.getPhoneNumber().matches(ParamsLimits.PHONE_NUMBER_FORMAT)) {
+			setErrorMessage(context, ErrorMessage.INVALID_PHONE_NUMBER_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 管理者名のチェック
+		// 不正文字列チェック
+		if (ParmCheckUtil.isParameterInvalid(form.getManagerName())) {
+			setErrorMessage(context, ErrorMessage.INVALID_INPUT_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 文字数チェック
+		if (form.getManagerName().length() > ParamsLimits.MANAGER_NAME_MAX_LENGTH) {
+			setErrorMessage(context, ErrorMessage.MANAGER_NAME_LENGTH_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 稼働状況ステータスのチェック
+		if (form.getOperationalStatus() != OperationalStatus.ACTIVE.getType() &&
+				form.getOperationalStatus() != OperationalStatus.INACTIVE.getType()) {
+			setErrorMessage(context, ErrorMessage.UNEXPECTED_INPUT_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 最大保管容量（m³）のチェック
+		if (Integer.parseInt(form.getMaxStorageCapacity()) < ParamsLimits.MIN_STORAGE_CAPACITY
+				|| Integer.parseInt(form.getMaxStorageCapacity()) > ParamsLimits.MAX_STORAGE_CAPACITY) {
+			setErrorMessage(context, ErrorMessage.INVALID_MAX_STORAGE_CAPACITY_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 現在保管容量（m³）のチェック
+		if (Integer.parseInt(form.getCurrentStorageCapacity()) < ParamsLimits.MIN__CURRENT_STORAGE_CAPACITY) {
+			setErrorMessage(context, ErrorMessage.INVALID_CURRENT_STORAGE_CAPACITY_ERROR_MESSAGE);
+			return false;
+		} else if (Integer.parseInt(form.getCurrentStorageCapacity()) > Integer
+				.parseInt(form.getMaxStorageCapacity())) {
+			setErrorMessage(context, ErrorMessage.INVALID_CURRENT_STORAGE_CAPACITY_OVER_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 備考のチェック
+		// 不正文字列チェック
+		if (ParmCheckUtil.isParameterInvalid(form.getNotes())) {
+			setErrorMessage(context, ErrorMessage.INVALID_INPUT_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 文字数チェック
+		if (form.getNotes().length() > ParamsLimits.NOTES_MAX_LENGTH) {
+			setErrorMessage(context, ErrorMessage.NOTES_LENGTH_ERROR_MESSAGE);
+			return false;
+		}
+
+		// その他のバリデーションに問題なければtrueを返す
+		return true;
+	}
+
+	/**	
+	 * エラーメッセージを設定
+	 * 
+	 * @param context
+	 * @param errorMessage
+	 * 
+	 */
+	private void setErrorMessage(ConstraintValidatorContext context, String errorMessage) {
+		context.disableDefaultConstraintViolation();
+		context.buildConstraintViolationWithTemplate(errorMessage)
+				.addConstraintViolation();
+	}
+}

--- a/DroneInventorySystem/src/main/resources/messages.properties
+++ b/DroneInventorySystem/src/main/resources/messages.properties
@@ -2,12 +2,42 @@
 allField.empty=すべてのフィールドが空です。少なくとも1つのフィールドに値を入力してください。
 unexpected.input=予期せぬ入力を検知しました。
 invalid.input=不正な文字列を検出しました。
+all.exception=予期せぬエラーが発生しました。管理者へ問い合わせください。（エラーコード：1）
+dataAccess.exception=データベース操作中にエラーが発生しました。管理者へ問い合わせください。
+nullPointer.exception=予期せぬエラーが発生しました。管理者へ問い合わせください。（エラーコード：2）
 
 # ログイン画面
 login.wrongInput=管理者IDとパスワードの組み合わせが間違っています。
 
 # 在庫センター情報画面
 centerName.length.wrongInput=センター名は20文字以内で入力してください。
+registration.completed=在庫センター情報の新規登録が完了しました。
+registration.error=予期せぬエラーを検知しました。システム管理者へ問い合わせください。(エラーコード：3）
+update.completed=在庫センター情報の更新が完了しました。
+update.error=予期せぬエラーを検知しました。システム管理者へ問い合わせください。(エラーコード：5）
+null.centerId=予期せぬエラーを検知しました。システム管理者へ問い合わせください。(エラーコード：4）
+
+# 在庫センター情報　登録画面
+invalid.postCode.Input=郵便番号は「000-0000」で入力してください。
+address.length.wrongInput=住所は15文字以内で入力してください。
+invalid.phoneNumber.Input=電話番号は半角数字で正しく入力してください。(ハイフン必須)
+managerName.length.wrongInput=管理者名は20文字以内で入力してください。
+invalid.maxStorageCapacity.Input=最大保管容量（m³）は1～9999未満の数値を入力してください。
+invalid.currentStorageCapacity.Input=現在容量は0～最大保存容量（㎥）までの数値を入力してください。
+invalid.currentStorageCapacity.over.Input=現在容量は最大容量を上回る容量を登録できません。
+notes.length.wrongInput=備考は100文字以内で入力してください。
+
+# 在庫センター情報　削除確認
+linked.centerId=対象の在庫センター情報は、在庫一覧情報に紐付けがあるため削除できません。
+
+# 在庫一覧画面
+stockName.length.wrongInput=在庫名は20文字以内で入力してください。
+categoryId.maximum.limit=不正な値を検知しました。
+stockNum.input=個数には1〜10000未満の数値を入力してください。
+
+# 分類情報管理画面
+category.length.wrongInput=分類名は1文字以上15文字以内で入力してください。
+category.empty=分類名を入力してください。
 
 # Spring Security が拾う例外のエラーメッセージをカスタマイズ
 AbstractUserDetailsAuthenticationProvider.badCredentials=管理者IDとパスワードの組み合わせが間違っています。

--- a/DroneInventorySystem/src/main/resources/static/css/custom-style.css
+++ b/DroneInventorySystem/src/main/resources/static/css/custom-style.css
@@ -1,0 +1,30 @@
+@charset "UTF-8";
+
+
+#custom-card-body{
+	width: 70% !important;
+	margin: auto !important;
+}
+#custom-underline{
+	text-decoration: underline !important;
+}
+#custom-text-center{
+	text-align: center !important;
+}
+.custom-text-left{
+	text-align: left !important;
+}
+.custum-btn-new{
+	color: #fff;
+	background-color: #CC0033 !important;
+	position: absolute !important;
+    bottom: 0px !important;
+    right: 0px !important;
+}
+
+.form-label{
+	width: 200px !important;  /* ラベルの固定幅を設定 */
+}
+#custum-form{
+	display: flex !important;
+}

--- a/DroneInventorySystem/src/main/resources/templates/admin/categoryInfoControl/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/categoryInfoControl/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+	th:replace="~{layout/template :: layout(~{::title},~{::body/content()})}">
+<head>
+<title>InvenTrack</title>
+</head>
+
+<body>
+	<div class="card shadow mb-4">
+
+		<div class="card-header py-3">
+			<h6 class="m-0 font-weight-bold text-primary">分類情報管理</h6>
+		</div>
+
+		<!-- CSS共通ファイル化のためコメント化
+		<div class="card-body" style="width: 70%; margin: auto;"> -->
+		<div class="card-body" id="custom-card-body">
+
+			<!-- 検索フォーム -->
+			<div class="search-container">
+				<form class="form-inline" method="post"
+					th:action="@{'/admin/categoryInfoControl/search'}"
+					th:object="${CategoryInfoControlForm}">
+					<!-- CSS共通ファイル化のためコメント化
+					<label for="searchTerm" class="mr-3"
+						style="text-decoration: underline;">検索条件</label> -->
+					<label for="searchTerm" class="mr-3" id="custom-underline">検索条件</label>
+					<label for="searchTerm" class="mr-2">分類名</label>
+					<input type="text"id="searchTerm" name="category" class="form-control mr-3">
+
+					<button type="submit" class="btn btn-primary">検索</button>
+				</form>
+
+				<!-- エラーメッセージの表示 -->
+				<div th:if="${errorMsg != null}" class="text-danger">
+					<p th:text="${errorMsg}"></p>
+				</div>
+				<!-- DB情報取得エラー時のメッセージの表示 -->
+				<div th:if="${dbErrorMsg != null}" class="text-danger">
+					<p th:text="${dbErrorMsg}"></p>
+				</div>
+			</div>
+
+			<!-- 分類情報テーブル -->
+			<!-- CSS共通ファイル化のためコメント化
+			<div class="table-responsive" style="text-align: center;"> -->
+			<div class="table-responsive"  id="custom-text-center">
+				<table class="table table-bordered" id="dataTable">
+					<tbody>
+						<!--/* 
+						分類名取得を定数クラス→DB取得に変更のためコメント化
+						<tr th:each="item : ${categoryConsts}">
+						<td>[[${item.category}]]</td>
+						 */-->
+						<tr th:each="item : ${categoryInfoList}">
+							<td>[[${item.categoryName}]]</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+
+</body>
+</html>

--- a/DroneInventorySystem/src/main/resources/templates/admin/centerInfo/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/centerInfo/index.html
@@ -1,13 +1,11 @@
 <!DOCTYPE html>
-<html
-  xmlns:th="http://www.thymeleaf.org"
-  th:replace="~{layout/template :: layout(~{::title},~{::body/content()})}"
->
-  <head>
-    <title>InvenTrack</title>
-  </head>
+<html xmlns:th="http://www.thymeleaf.org"
+	th:replace="~{layout/template :: layout(~{::title},~{::body/content()})}">
+<head>
+<title>InvenTrack</title>
+</head>
 
-  <body>
+<body>
 	<div class="card shadow mb-4">
 
 		<div class="card-header py-3">
@@ -15,35 +13,41 @@
 		</div>
 
 		<div class="card-body">
-			
+
 			<!-- 検索フォーム -->
 			<div class="search-container">
-				<form class="form-inline" method="post" th:action="@{'/admin/centerInfo/search'}" th:object="${CenterInfoForm}">
-					<label for="searchTerm" class="mr-2">検索条件</label>
-					
-					<label for="searchTerm" class="mr-2">センター名</label>
- 					<input type="text" id="searchTerm" name="centerName" class="form-control mr-2">
- 					
- 					<label for="searchTerm" class="mr-2">都道府県</label>
- 					<select id="searchTerm" name="region" class="form-control mr-2">
-						 <option value="">選択してください</option>
-						 <option th:each="region : ${regions}" 
-						 	th:value="${region.name}" 
-						 	th:text="${region.name}"></option>
+				<form class="form-inline" method="post"
+					th:action="@{'/admin/centerInfo/search'}"
+					th:object="${CenterInfoForm}">
+					<label for="searchTerm" class="mr-2">検索条件</label> <label
+						for="searchTerm" class="mr-2">センター名</label> <input type="text"
+						id="searchTerm" name="centerName" class="form-control mr-2">
+
+					<label for="searchTerm" class="mr-2">都道府県</label> <select
+						id="searchTerm" name="region" class="form-control mr-2">
+						<option value="">選択してください</option>
+						<option th:each="region : ${regions}" th:value="${region.name}"
+							th:text="${region.name}"></option>
 					</select>
-					
- 					<button type="submit" class="btn btn-primary">検索</button>
- 				</form>
- 				
- 				<!-- エラーメッセージの表示 -->
- 				<div th:if="${errorMsg != null}" class="text-danger">
-					 <p th:text="${errorMsg}"></p>
+
+					<button type="submit" class="btn btn-primary">検索</button>
+				</form>
+
+				<!-- エラーメッセージの表示 -->
+				<div th:if="${errorMsg != null}" class="text-danger">
+					<p th:text="${errorMsg}"></p>
+				</div>
+
+				<!-- 登録完了メッセージ表示 -->
+				<div th:if="${completedMsg != null}" class="text-success">
+					<p th:text="${completedMsg}"></p>
 				</div>
 			</div>
- 			
+
 			<!-- 在庫センター情報テーブル -->
 			<div class="table-responsive">
-				<table class="table table-bordered" id="dataTable" width="100%" cellspacing="0">
+				<table class="table table-bordered" id="dataTable" width="100%"
+					cellspacing="0">
 					<thead>
 						<tr>
 							<th>センター名</th>
@@ -54,15 +58,21 @@
 					</thead>
 					<tbody>
 						<tr th:each="item : ${centerInfoList}">
-							<td> [[${item.centerName}]] </td>
-							<td> [[${item.address}]] </td>
-							<td> [[${item.phoneNumber}]] </td>
-							<td> [[${item.managerName}]] </td>
+							<td><a
+								th:href="@{/admin/centerInfo/details/{centerId}(centerId=${item.centerId})}">[[${item.centerName}]]</a></td>
+							<td>[[${item.address}]]</td>
+							<td>[[${item.phoneNumber}]]</td>
+							<td>[[${item.managerName}]]</td>
 						</tr>
 					</tbody>
 				</table>
 			</div>
+			<!-- 新規登録ボタン -->
+			<form class="form-inline" method="get"
+				th:action="@{'/admin/centerInfo/register'}">
+				<button type="submit" class="btn custum-btn-new">新規登録</button>
+			</form>
 		</div>
 	</div>
-  </body>
+</body>
 </html>

--- a/DroneInventorySystem/src/main/resources/templates/admin/centerInfo/register.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/centerInfo/register.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+	th:replace="~{layout/template :: layout(~{::title},~{::body/content()})}">
+<head>
+<title>InvenTrack - 登録</title>
+</head>
+
+<body>
+	<div class="card shadow mb-4">
+
+		<div class="card-header py-3">
+			<h6 class="m-0 font-weight-bold text-primary">在庫センター情報 登録</h6>
+		</div>
+
+		<!-- 登録フォーム -->
+
+		<div class="d-flex justify-content-center align-items-center">
+			<div class="card shadow-lg" style="width: 70%; max-width: 800px">
+				<div class="card-body py-2">
+					<form class="small" method="post"
+						th:action="@{'/admin/centerInfo/registrationCompleted'}">
+
+						<div class="mb-2" id="custum-form">
+							<label for="centerName" class="form-label"><span
+								class="text-danger">*</span> 必須項目</label>
+							<!-- エラーメッセージの表示 -->
+							<div th:if="${errorMsg != null}" class="text-danger">
+								<p th:text="${errorMsg}"></p>
+							</div>
+						</div>
+
+						<!-- 在庫センター名 -->
+						<div class="mb-2" id="custum-form">
+							<label for="centerName" class="form-label">在庫センター名<span
+								class="text-danger">*</span></label> <input type="text"
+								class="form-control form-control-sm" id="centerName"
+								name="centerName" placeholder="○○物流センター" required />
+						</div>
+
+						<!-- 郵便番号 -->
+						<div class="mb-2" id="custum-form">
+							<label for="postCode" class="form-label">郵便番号<span
+								class="text-danger">*</span></label> <input type="text"
+								class="form-control form-control-sm" id="postCode"
+								name="postCode" placeholder="000-0000" required />
+						</div>
+
+						<!-- 住所 -->
+						<div class="mb-2" id="custum-form">
+							<label for="address" class="form-label">住所<span
+								class="text-danger">*</span></label> <input type="text"
+								class="form-control form-control-sm" id="address" name="address"
+								placeholder="〇県〇市" required />
+						</div>
+
+						<!-- 電話番号 -->
+						<div class="mb-2" id="custum-form">
+							<label for="phoneNumber" class="form-label">電話番号<span
+								class="text-danger">*</span></label> <input type="text"
+								class="form-control form-control-sm" id="phoneNumber"
+								name="phoneNumber" placeholder="000-0000-0000" required />
+						</div>
+
+						<!-- 管理者名 -->
+						<div class="mb-2" id="custum-form">
+							<label for="managerName" class="form-label">管理者名<span
+								class="text-danger">*</span></label> <input type="text"
+								class="form-control form-control-sm" id="managerName"
+								name="managerName" placeholder="田中太郎" required />
+						</div>
+
+						<!-- 稼働状況ステータス -->
+						<div class="mb-2" id="custum-form">
+							<label class="form-label">稼働状況ステータス<span
+								class="text-danger">*</span></label>
+							<div class="form-check form-check-inline">
+								<input class="form-check-input" type="radio" value="0"
+									id="operationalStatusActive" name="operationalStatus" required
+									checked /> <label class="form-check-label"
+									for="operationalStatusActive">稼働中</label>
+							</div>
+							<div class="form-check form-check-inline">
+								<input class="form-check-input" type="radio" value="1"
+									id="operationalStatusInactive" name="operationalStatus"
+									required /> <label class="form-check-label"
+									for="operationalStatusInactive">稼働停止</label>
+							</div>
+						</div>
+
+						<!-- 最大保管容量 -->
+						<div class="mb-2" id="custum-form">
+							<label for="maxStorageCapacity" class="form-label">最大保管容量（m³）<span
+								class="text-danger">*</span></label> <input type="number"
+								class="form-control form-control-sm" id="maxStorageCapacity"
+								name="maxStorageCapacity" placeholder="500" required />
+						</div>
+
+						<!-- 現在保管容量 -->
+						<div class="mb-2" id="custum-form">
+							<label for="currentStorageCapacity" class="form-label">現在保管容量（m³）<span
+								class="text-danger">*</span></label> <input type="number"
+								class="form-control form-control-sm" id="currentStorageCapacity"
+								name="currentStorageCapacity" placeholder="250" required />
+						</div>
+
+						<!-- 備考 -->
+						<div class="mb-2" id="custum-form">
+							<label for="notes" class="form-label">備考</label>
+							<textarea class="form-control form-control-sm" id="notes"
+								name="notes" rows="2"></textarea>
+						</div>
+
+						<!-- 「＊」必須項目の説明 -->
+						<div class="mb-2" id="custum-form">
+							<span class="text-danger">*</span><span>の付いている項目は必須入力です。</span>
+						</div>
+
+						<!-- ボタン -->
+						<div class="d-flex justify-content-between">
+							<a href="/admin/centerInfo" class="btn btn-secondary btn-sm">キャンセル</a>
+							<button type="submit" class="btn btn-success btn-sm">
+								登録する</button>
+						</div>
+					</form>
+				</div>
+			</div>
+		</div>
+	</div>
+</body>
+</html>

--- a/DroneInventorySystem/src/main/resources/templates/admin/centerInfo/update.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/centerInfo/update.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+	th:replace="~{layout/template :: layout(~{::title},~{::body/content()})}">
+<head>
+<title>InvenTrack - 更新</title>
+</head>
+
+<body>
+	<div class="card shadow mb-4">
+
+		<div class="card-header py-3">
+			<h6 class="m-0 font-weight-bold text-primary">在庫センター情報 更新/削除</h6>
+		</div>
+
+		<!-- 更新フォーム -->
+
+		<div class="d-flex justify-content-center align-items-center">
+			<div class="card shadow-lg" style="width: 70%; max-width: 800px">
+				<div class="card-body py-2">
+					<form class="small" method="post"
+						th:action="@{'/admin/centerInfo/update'}"
+						th:each="center : ${centerInfoList}">
+
+						<!-- 在庫センターID -->
+						<input type="hidden" class="form-control form-control-sm"
+							id="centerId" name="centerId" th:value="${center.centerId}" />
+						<!-- 作成日 -->
+						<input type="hidden" class="form-control form-control-sm"
+							id="deleteFlag" name="deleteFlag" th:value="${center.deleteFlag}" />
+
+						<div class="mb-2" id="custum-form">
+							<label for="centerName" class="form-label"><span
+								class="text-danger">*</span> 必須項目</label>
+							<!-- エラーメッセージの表示 -->
+							<div th:if="${errorMsg != null}" class="text-danger">
+								<p th:text="${errorMsg}"></p>
+							</div>
+						</div>
+
+						<!-- 在庫センター名 -->
+						<div class="mb-2" id="custum-form">
+							<label for="centerName" class="form-label">在庫センター名<span
+								class="text-danger">*</span></label> <input type="text"
+								class="form-control form-control-sm" id="centerName"
+								name="centerName" placeholder="○○物流センター"
+								th:value="${center.centerName}" required />
+						</div>
+
+						<!-- 郵便番号 -->
+						<div class="mb-2" id="custum-form">
+							<label for="postCode" class="form-label">郵便番号<span
+								class="text-danger">*</span></label> <input type="text"
+								class="form-control form-control-sm" id="postCode"
+								name="postCode" placeholder="000-0000"
+								th:value="${center.postCode}" required />
+						</div>
+
+						<!-- 住所 -->
+						<div class="mb-2" id="custum-form">
+							<label for="address" class="form-label">住所<span
+								class="text-danger">*</span></label> <input type="text"
+								class="form-control form-control-sm" id="address" name="address"
+								placeholder="〇県〇市" th:value="${center.address}" required />
+						</div>
+
+						<!-- 電話番号 -->
+						<div class="mb-2" id="custum-form">
+							<label for="phoneNumber" class="form-label">電話番号<span
+								class="text-danger">*</span></label> <input type="text"
+								class="form-control form-control-sm" id="phoneNumber"
+								name="phoneNumber" placeholder="000-0000-0000"
+								th:value="${center.phoneNumber}" required />
+						</div>
+
+						<!-- 管理者名 -->
+						<div class="mb-2" id="custum-form">
+							<label for="managerName" class="form-label">管理者名<span
+								class="text-danger">*</span></label> <input type="text"
+								class="form-control form-control-sm" id="managerName"
+								name="managerName" placeholder="田中太郎"
+								th:value="${center.managerName}" required />
+						</div>
+
+						<!-- 稼働状況ステータス -->
+						<div class="mb-2" id="custum-form">
+							<label class="form-label">稼働状況ステータス<span
+								class="text-danger">*</span></label>
+							<div class="form-check form-check-inline">
+								<input class="form-check-input" type="radio" value="0"
+									id="operationalStatusActive" name="operationalStatus" required
+									th:attr="checked=${center.operationalStatus == 0}" /> <label
+									class="form-check-label" for="operationalStatusActive">稼働中</label>
+							</div>
+							<div class="form-check form-check-inline">
+								<input class="form-check-input" type="radio" value="1"
+									id="operationalStatusInactive" name="operationalStatus"
+									required th:attr="checked=${center.operationalStatus == 1}" />
+								<label class="form-check-label" for="operationalStatusInactive">稼働停止</label>
+							</div>
+						</div>
+
+						<!-- 最大保管容量 -->
+						<div class="mb-2" id="custum-form">
+							<label for="maxStorageCapacity" class="form-label">最大保管容量（m³）<span
+								class="text-danger">*</span></label> <input type="number"
+								class="form-control form-control-sm" id="maxStorageCapacity"
+								name="maxStorageCapacity" placeholder="500"
+								th:value="${center.maxStorageCapacity}" required />
+						</div>
+
+						<!-- 現在保管容量 -->
+						<div class="mb-2" id="custum-form">
+							<label for="currentStorageCapacity" class="form-label">現在保管容量（m³）<span
+								class="text-danger">*</span></label> <input type="number"
+								class="form-control form-control-sm" id="currentStorageCapacity"
+								name="currentStorageCapacity" placeholder="250"
+								th:value="${center.currentStorageCapacity}" required />
+						</div>
+
+						<!-- 備考 -->
+						<div class="mb-2" id="custum-form">
+							<label for="notes" class="form-label">備考</label>
+							<textarea class="form-control form-control-sm" id="notes"
+								name="notes" rows="2" th:value="${center.notes}"></textarea>
+						</div>
+
+						<!-- 「＊」必須項目の説明 -->
+						<div class="mb-2" id="custum-form">
+							<span class="text-danger">*</span><span>の付いている項目は必須入力です。</span>
+						</div>
+
+
+						<!-- ボタン -->
+						<div class="d-flex justify-content-between">
+							<a href="/admin/centerInfo" class="btn btn-secondary btn-sm">キャンセル</a>
+							<div>
+								<a
+									th:href="@{/admin/centerInfo/delete/{centerId}(centerId=${center.centerId})}"
+									class="btn btn-primary btn-sm">削除する</a>
+								<button type="submit" class="btn btn-success btn-sm">
+									更新する</button>
+							</div>
+						</div>
+
+					</form>
+				</div>
+			</div>
+		</div>
+	</div>
+</body>
+</html>

--- a/DroneInventorySystem/src/main/resources/templates/admin/stockList/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/stockList/index.html
@@ -1,497 +1,76 @@
 <!DOCTYPE html>
-<html
-  xmlns:th="http://www.thymeleaf.org"
-  th:replace="~{layout/template :: layout(~{::title},~{::body/content()})}"
->
-  <head>
-    <title>InvenTrack</title>
-  </head>
+<html xmlns:th="http://www.thymeleaf.org"
+	th:replace="~{layout/template :: layout(~{::title},~{::body/content()})}">
+<head>
+<title>InvenTrack</title>
+</head>
+<body>
+	<div class="card shadow mb-4">
+		<div class="card-header py-3">
+			<h6 class="m-0 font-weight-bold text-primary">在庫一覧</h6>
+		</div>
 
-  <body>
-    <div class="card shadow mb-4">
-      <div class="card-header py-3">
-        <h6 class="m-0 font-weight-bold text-primary">HOME</h6>
-      </div>
+		<div class="card-body">
 
-      <div class="card-body">
-        <div class="table-responsive">
-          <table
-            class="table table-bordered"
-            id="dataTable"
-            width="100%"
-            cellspacing="0"
-          >
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Position</th>
-                <th>Office</th>
-                <th>Age</th>
-                <th>Start date</th>
-                <th>Salary</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>Tiger Nixon</td>
-                <td>System Architect</td>
-                <td>Edinburgh</td>
-                <td>61</td>
-                <td>2011/04/25</td>
-                <td>$320,800</td>
-              </tr>
-              <tr>
-                <td>Garrett Winters</td>
-                <td>Accountant</td>
-                <td>Tokyo</td>
-                <td>63</td>
-                <td>2011/07/25</td>
-                <td>$170,750</td>
-              </tr>
-              <tr>
-                <td>Ashton Cox</td>
-                <td>Junior Technical Author</td>
-                <td>San Francisco</td>
-                <td>66</td>
-                <td>2009/01/12</td>
-                <td>$86,000</td>
-              </tr>
-              <tr>
-                <td>Cedric Kelly</td>
-                <td>Senior Javascript Developer</td>
-                <td>Edinburgh</td>
-                <td>22</td>
-                <td>2012/03/29</td>
-                <td>$433,060</td>
-              </tr>
-              <tr>
-                <td>Airi Satou</td>
-                <td>Accountant</td>
-                <td>Tokyo</td>
-                <td>33</td>
-                <td>2008/11/28</td>
-                <td>$162,700</td>
-              </tr>
-              <tr>
-                <td>Brielle Williamson</td>
-                <td>Integration Specialist</td>
-                <td>New York</td>
-                <td>61</td>
-                <td>2012/12/02</td>
-                <td>$372,000</td>
-              </tr>
-              <tr>
-                <td>Herrod Chandler</td>
-                <td>Sales Assistant</td>
-                <td>San Francisco</td>
-                <td>59</td>
-                <td>2012/08/06</td>
-                <td>$137,500</td>
-              </tr>
-              <tr>
-                <td>Rhona Davidson</td>
-                <td>Integration Specialist</td>
-                <td>Tokyo</td>
-                <td>55</td>
-                <td>2010/10/14</td>
-                <td>$327,900</td>
-              </tr>
-              <tr>
-                <td>Colleen Hurst</td>
-                <td>Javascript Developer</td>
-                <td>San Francisco</td>
-                <td>39</td>
-                <td>2009/09/15</td>
-                <td>$205,500</td>
-              </tr>
-              <tr>
-                <td>Sonya Frost</td>
-                <td>Software Engineer</td>
-                <td>Edinburgh</td>
-                <td>23</td>
-                <td>2008/12/13</td>
-                <td>$103,600</td>
-              </tr>
-              <tr>
-                <td>Jena Gaines</td>
-                <td>Office Manager</td>
-                <td>London</td>
-                <td>30</td>
-                <td>2008/12/19</td>
-                <td>$90,560</td>
-              </tr>
-              <tr>
-                <td>Quinn Flynn</td>
-                <td>Support Lead</td>
-                <td>Edinburgh</td>
-                <td>22</td>
-                <td>2013/03/03</td>
-                <td>$342,000</td>
-              </tr>
-              <tr>
-                <td>Charde Marshall</td>
-                <td>Regional Director</td>
-                <td>San Francisco</td>
-                <td>36</td>
-                <td>2008/10/16</td>
-                <td>$470,600</td>
-              </tr>
-              <tr>
-                <td>Haley Kennedy</td>
-                <td>Senior Marketing Designer</td>
-                <td>London</td>
-                <td>43</td>
-                <td>2012/12/18</td>
-                <td>$313,500</td>
-              </tr>
-              <tr>
-                <td>Tatyana Fitzpatrick</td>
-                <td>Regional Director</td>
-                <td>London</td>
-                <td>19</td>
-                <td>2010/03/17</td>
-                <td>$385,750</td>
-              </tr>
-              <tr>
-                <td>Michael Silva</td>
-                <td>Marketing Designer</td>
-                <td>London</td>
-                <td>66</td>
-                <td>2012/11/27</td>
-                <td>$198,500</td>
-              </tr>
-              <tr>
-                <td>Paul Byrd</td>
-                <td>Chief Financial Officer (CFO)</td>
-                <td>New York</td>
-                <td>64</td>
-                <td>2010/06/09</td>
-                <td>$725,000</td>
-              </tr>
-              <tr>
-                <td>Gloria Little</td>
-                <td>Systems Administrator</td>
-                <td>New York</td>
-                <td>59</td>
-                <td>2009/04/10</td>
-                <td>$237,500</td>
-              </tr>
-              <tr>
-                <td>Bradley Greer</td>
-                <td>Software Engineer</td>
-                <td>London</td>
-                <td>41</td>
-                <td>2012/10/13</td>
-                <td>$132,000</td>
-              </tr>
-              <tr>
-                <td>Dai Rios</td>
-                <td>Personnel Lead</td>
-                <td>Edinburgh</td>
-                <td>35</td>
-                <td>2012/09/26</td>
-                <td>$217,500</td>
-              </tr>
-              <tr>
-                <td>Jenette Caldwell</td>
-                <td>Development Lead</td>
-                <td>New York</td>
-                <td>30</td>
-                <td>2011/09/03</td>
-                <td>$345,000</td>
-              </tr>
-              <tr>
-                <td>Yuri Berry</td>
-                <td>Chief Marketing Officer (CMO)</td>
-                <td>New York</td>
-                <td>40</td>
-                <td>2009/06/25</td>
-                <td>$675,000</td>
-              </tr>
-              <tr>
-                <td>Caesar Vance</td>
-                <td>Pre-Sales Support</td>
-                <td>New York</td>
-                <td>21</td>
-                <td>2011/12/12</td>
-                <td>$106,450</td>
-              </tr>
-              <tr>
-                <td>Doris Wilder</td>
-                <td>Sales Assistant</td>
-                <td>Sidney</td>
-                <td>23</td>
-                <td>2010/09/20</td>
-                <td>$85,600</td>
-              </tr>
-              <tr>
-                <td>Angelica Ramos</td>
-                <td>Chief Executive Officer (CEO)</td>
-                <td>London</td>
-                <td>47</td>
-                <td>2009/10/09</td>
-                <td>$1,200,000</td>
-              </tr>
-              <tr>
-                <td>Gavin Joyce</td>
-                <td>Developer</td>
-                <td>Edinburgh</td>
-                <td>42</td>
-                <td>2010/12/22</td>
-                <td>$92,575</td>
-              </tr>
-              <tr>
-                <td>Jennifer Chang</td>
-                <td>Regional Director</td>
-                <td>Singapore</td>
-                <td>28</td>
-                <td>2010/11/14</td>
-                <td>$357,650</td>
-              </tr>
-              <tr>
-                <td>Brenden Wagner</td>
-                <td>Software Engineer</td>
-                <td>San Francisco</td>
-                <td>28</td>
-                <td>2011/06/07</td>
-                <td>$206,850</td>
-              </tr>
-              <tr>
-                <td>Fiona Green</td>
-                <td>Chief Operating Officer (COO)</td>
-                <td>San Francisco</td>
-                <td>48</td>
-                <td>2010/03/11</td>
-                <td>$850,000</td>
-              </tr>
-              <tr>
-                <td>Shou Itou</td>
-                <td>Regional Marketing</td>
-                <td>Tokyo</td>
-                <td>20</td>
-                <td>2011/08/14</td>
-                <td>$163,000</td>
-              </tr>
-              <tr>
-                <td>Michelle House</td>
-                <td>Integration Specialist</td>
-                <td>Sidney</td>
-                <td>37</td>
-                <td>2011/06/02</td>
-                <td>$95,400</td>
-              </tr>
-              <tr>
-                <td>Suki Burks</td>
-                <td>Developer</td>
-                <td>London</td>
-                <td>53</td>
-                <td>2009/10/22</td>
-                <td>$114,500</td>
-              </tr>
-              <tr>
-                <td>Prescott Bartlett</td>
-                <td>Technical Author</td>
-                <td>London</td>
-                <td>27</td>
-                <td>2011/05/07</td>
-                <td>$145,000</td>
-              </tr>
-              <tr>
-                <td>Gavin Cortez</td>
-                <td>Team Leader</td>
-                <td>San Francisco</td>
-                <td>22</td>
-                <td>2008/10/26</td>
-                <td>$235,500</td>
-              </tr>
-              <tr>
-                <td>Martena Mccray</td>
-                <td>Post-Sales support</td>
-                <td>Edinburgh</td>
-                <td>46</td>
-                <td>2011/03/09</td>
-                <td>$324,050</td>
-              </tr>
-              <tr>
-                <td>Unity Butler</td>
-                <td>Marketing Designer</td>
-                <td>San Francisco</td>
-                <td>47</td>
-                <td>2009/12/09</td>
-                <td>$85,675</td>
-              </tr>
-              <tr>
-                <td>Howard Hatfield</td>
-                <td>Office Manager</td>
-                <td>San Francisco</td>
-                <td>51</td>
-                <td>2008/12/16</td>
-                <td>$164,500</td>
-              </tr>
-              <tr>
-                <td>Hope Fuentes</td>
-                <td>Secretary</td>
-                <td>San Francisco</td>
-                <td>41</td>
-                <td>2010/02/12</td>
-                <td>$109,850</td>
-              </tr>
-              <tr>
-                <td>Vivian Harrell</td>
-                <td>Financial Controller</td>
-                <td>San Francisco</td>
-                <td>62</td>
-                <td>2009/02/14</td>
-                <td>$452,500</td>
-              </tr>
-              <tr>
-                <td>Timothy Mooney</td>
-                <td>Office Manager</td>
-                <td>London</td>
-                <td>37</td>
-                <td>2008/12/11</td>
-                <td>$136,200</td>
-              </tr>
-              <tr>
-                <td>Jackson Bradshaw</td>
-                <td>Director</td>
-                <td>New York</td>
-                <td>65</td>
-                <td>2008/09/26</td>
-                <td>$645,750</td>
-              </tr>
-              <tr>
-                <td>Olivia Liang</td>
-                <td>Support Engineer</td>
-                <td>Singapore</td>
-                <td>64</td>
-                <td>2011/02/03</td>
-                <td>$234,500</td>
-              </tr>
-              <tr>
-                <td>Bruno Nash</td>
-                <td>Software Engineer</td>
-                <td>London</td>
-                <td>38</td>
-                <td>2011/05/03</td>
-                <td>$163,500</td>
-              </tr>
-              <tr>
-                <td>Sakura Yamamoto</td>
-                <td>Support Engineer</td>
-                <td>Tokyo</td>
-                <td>37</td>
-                <td>2009/08/19</td>
-                <td>$139,575</td>
-              </tr>
-              <tr>
-                <td>Thor Walton</td>
-                <td>Developer</td>
-                <td>New York</td>
-                <td>61</td>
-                <td>2013/08/11</td>
-                <td>$98,540</td>
-              </tr>
-              <tr>
-                <td>Finn Camacho</td>
-                <td>Support Engineer</td>
-                <td>San Francisco</td>
-                <td>47</td>
-                <td>2009/07/07</td>
-                <td>$87,500</td>
-              </tr>
-              <tr>
-                <td>Serge Baldwin</td>
-                <td>Data Coordinator</td>
-                <td>Singapore</td>
-                <td>64</td>
-                <td>2012/04/09</td>
-                <td>$138,575</td>
-              </tr>
-              <tr>
-                <td>Zenaida Frank</td>
-                <td>Software Engineer</td>
-                <td>New York</td>
-                <td>63</td>
-                <td>2010/01/04</td>
-                <td>$125,250</td>
-              </tr>
-              <tr>
-                <td>Zorita Serrano</td>
-                <td>Software Engineer</td>
-                <td>San Francisco</td>
-                <td>56</td>
-                <td>2012/06/01</td>
-                <td>$115,000</td>
-              </tr>
-              <tr>
-                <td>Jennifer Acosta</td>
-                <td>Junior Javascript Developer</td>
-                <td>Edinburgh</td>
-                <td>43</td>
-                <td>2013/02/01</td>
-                <td>$75,650</td>
-              </tr>
-              <tr>
-                <td>Cara Stevens</td>
-                <td>Sales Assistant</td>
-                <td>New York</td>
-                <td>46</td>
-                <td>2011/12/06</td>
-                <td>$145,600</td>
-              </tr>
-              <tr>
-                <td>Hermione Butler</td>
-                <td>Regional Director</td>
-                <td>London</td>
-                <td>47</td>
-                <td>2011/03/21</td>
-                <td>$356,250</td>
-              </tr>
-              <tr>
-                <td>Lael Greer</td>
-                <td>Systems Administrator</td>
-                <td>London</td>
-                <td>21</td>
-                <td>2009/02/27</td>
-                <td>$103,500</td>
-              </tr>
-              <tr>
-                <td>Jonas Alexander</td>
-                <td>Developer</td>
-                <td>San Francisco</td>
-                <td>30</td>
-                <td>2010/07/14</td>
-                <td>$86,500</td>
-              </tr>
-              <tr>
-                <td>Shad Decker</td>
-                <td>Regional Director</td>
-                <td>Edinburgh</td>
-                <td>51</td>
-                <td>2008/11/13</td>
-                <td>$183,000</td>
-              </tr>
-              <tr>
-                <td>Michael Bruce</td>
-                <td>Javascript Developer</td>
-                <td>Singapore</td>
-                <td>29</td>
-                <td>2011/06/27</td>
-                <td>$183,000</td>
-              </tr>
-              <tr>
-                <td>Donna Snider</td>
-                <td>Customer Support</td>
-                <td>New York</td>
-                <td>27</td>
-                <td>2011/01/25</td>
-                <td>$112,000</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-  </body>
+			<!-- 検索フォーム -->
+			<div class="search-container">
+				<form class="form-inline" method="post"
+					th:action="@{'/admin/stockList/search'}"
+					th:object="${StockInfoForm}">
+
+					<label for="searchTerm" class="mr-3" id="custom-underline">検索条件</label>
+
+					<label for="searchTerm" class="mr-2">分類</label> <select
+						id="searchTerm" name="categoryId" class="form-control mr-2">
+						<option value="">すべて</option>
+						<option th:each="categoryInfo : ${categoryInfoList}"
+							th:value="${categoryInfo.categoryId}"
+							th:text="${categoryInfo.categoryName}"></option>
+
+					</select> <label for="searchTerm" class="mr-2">名称</label> <input type="text"
+						id="searchTerm" name="name" class="form-control mr-2">
+
+					<!-- 「以上」「以下」を定数にする -->
+					<label for="searchTerm" class="mr-2">個数</label> <input type="number"
+						id="searchTerm" name="amount" class="form-control mr-0"> <select
+						id="searchTerm" name="range" class="form-control mr-2">
+						<option th:each="rangeType : ${rangeType}"
+							th:value="${rangeType.name}" th:text="${rangeType.type}"></option>
+					</select>
+
+					<button type="submit" class="btn btn-primary">検索</button>
+				</form>
+
+				<!-- エラーメッセージの表示 -->
+				<div th:if="${errorMsg != null}" class="text-danger">
+					<p th:text="${errorMsg}"></p>
+				</div>
+			</div>
+
+			<!-- 在庫一覧テーブル -->
+			<div class="table-responsive" id="custom-text-center">
+				<table class="table table-bordered" id="dataTable">
+					<thead>
+						<tr>
+							<th>分類</th>
+							<th>名称</th>
+							<th>個数</th>
+							<th>保管場所</th>
+							<th>説明</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr th:each="item : ${stockInfoList}">
+							<td>[[${item.categoryName}]]</td>
+							<td>[[${item.Name}]]</td>
+							<td>[[${item.amount}]]</td>
+							<td>[[${item.centerName}]]</td>
+							<td class=custom-text-left>[[${item.description}]]</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+</body>
 </html>

--- a/DroneInventorySystem/src/main/resources/templates/layout/navbar.html
+++ b/DroneInventorySystem/src/main/resources/templates/layout/navbar.html
@@ -26,7 +26,7 @@
 				<a class="nav-link" th:href="@{'/admin/stockList'}">
 					<span>在庫一覧</span>
 				</a>
-				<a class="nav-link" th:href="@{'/admin/stockList'}">
+				<a class="nav-link" th:href="@{'/admin/categoryInfoControl'}">
 					<span>分類情報管理</span>
 				</a>
 				<a class="nav-link" th:href="@{'/admin/centerInfo'}">

--- a/DroneInventorySystem/src/main/resources/templates/layout/template.html
+++ b/DroneInventorySystem/src/main/resources/templates/layout/template.html
@@ -14,6 +14,8 @@
 
 	<!-- Custom styles for this template-->
 	<link th:href="@{/css/sb-admin-2.min.css}" rel="stylesheet" type="text/css" media="screen, projection" />
+	<!-- 個別ページのCustom styles-->
+	<link rel="stylesheet" type="text/css" th:href="@{/css/custom-style.css}">
 </head>
 
 <body>


### PR DESCRIPTION
## 🏅 概要
在庫センター情報画面の主に以下機能を実装しました。
・一覧表示
・検索機能
・登録機能
・更新機能

## 💭 追加・変更内容
・在庫センター情報を管理する画面を新規作成
・検索条件によるフィルタリング処理を実装
・新規登録フォームを追加
・既存データの編集機能を実装
・バリデーション処理およびエラーハンドリングを追加
　※開発初期段階のため、削除機能は未対応です。
 

## 💡 影響範囲・懸念点
・在庫一覧画面が、在庫センター情報を参照しているため、影響を受ける可能性があるため、
　在庫一覧で使用されている在庫センター情報は、更新できないようにしている。


## Review
### 📘 仕様 <!-- チケットなど仕様の根拠があれば -->
概要
在庫センターに関する情報を管理する画面に登録/更新機能を追加実装

・登録機能
　在庫センター情報を新規登録できる。
　テーブル定義書のシート「在庫センター情報テーブル」の通り登録できること。
　※カラム追加に伴う改修が必要。

・更新機能
　既存の在庫センター情報を編集・更新できる。
　※カラム追加に伴う改修が必要。



### 🛡️ 確認事項
・一覧表示の動作確認（表示件数、ソート）
・検索機能の動作確認（センター名、拠点コードでの検索）
・登録機能の動作確認（正常系・異常系）
・更新機能の動作確認（正常系・異常系）

### ▶️ 動作サンプル <!-- 実際に動く環境へのURL または スクショ・動画など -->
<!-- もし特定のアカウントでしか確認できない場合は、アカウント情報も記載 -->
local環境にて実施しました。
